### PR TITLE
129 simulator: make the clear db tables method dynamic for the tables to clear

### DIFF
--- a/database/init_db.py
+++ b/database/init_db.py
@@ -105,14 +105,16 @@ def create_tables_if_they_dont_already_exist(app:flask.app.Flask) -> str:
 
     return result
 
-def clear_db_tables() -> str:
-    new_dbname = environ.get('DBNAME')
+def clear_db_tables(tables: list) -> str:
     result = "Tables cleared successfully!"
 
+    tables_str = ', '.join(tables)
+
+    connection = None
     try:
         connection = db_cursor('genlayer_state')
         cursor = connection.cursor()
-        cursor.execute(f"TRUNCATE TABLE transactions, current_state, validators RESTART IDENTITY")
+        cursor.execute(f"TRUNCATE TABLE {tables_str} RESTART IDENTITY")
         cursor.close()
         connection.commit()
     except (Exception, psycopg2.DatabaseError) as error:

--- a/rpc/server.py
+++ b/rpc/server.py
@@ -79,9 +79,9 @@ def create_tables() -> dict:
     return {"status": result}
 
 
-@jsonrpc.method("clear_tables")
-def clear_tables() -> dict:
-    result = clear_db_tables()
+@jsonrpc.method("clear_account_and_transactions_tables")
+def clear_account_and_transactions_tables() -> dict:
+    result = clear_db_tables(["current_state", "transactions"])
     app.logger.info(result)
     return {"status": result}
 


### PR DESCRIPTION
@bradleySuira and @sevenearths please check that the old method `clear_tables` is not being used on any other place.