### PR TITLE
114 simulator frontend: always send from_address argument to backend calls

### DIFF
--- a/consensus/algorithm.py
+++ b/consensus/algorithm.py
@@ -92,7 +92,7 @@ def validator_executes_transaction(
     return return_value
 
 
-async def exec_transaction(transaction_input, logger=None):
+async def exec_transaction(from_account, transaction_input, logger=None):
 
     with DatabaseFunctions() as dbf:
         all_validators = dbf.all_validators()
@@ -146,7 +146,7 @@ async def exec_transaction(transaction_input, logger=None):
     #     votes[f"{validation_results[i]['validator']}"] = validation_results[i]["vote"]
 
     # Write transaction into DB
-    from_address = transaction_input["args"][0]
+    from_address = from_account
     to_address = transaction_input["contract_address"]
     data = json.dumps(
         {"new_contract_state": leader_receipt["result"]["contract_state"]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "genlayer-simulator",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/rpc/server.py
+++ b/rpc/server.py
@@ -450,7 +450,7 @@ async def call_contract_function(
 
         # TODO: More logging needs to be done inside the consensus functionallity
         # call consensus
-        execution_output = await exec_transaction(json.loads(function_call_data), logger=log_status)
+        execution_output = await exec_transaction(from_account, json.loads(function_call_data), logger=log_status)
 
         cursor.close()
         connection.close()


### PR DESCRIPTION
The address calling the contract function has been passed to the exec_transaction of the consensus to avoid having to look for it in the transaction arguments