### PR TITLE
241 SIM gh-action-to-run-unit-tests-on-pr-open-and-approvals

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -13,5 +13,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "21.x"
+
       - run: npm ci
+        working-directory: frontend
       - run: npm run test:unit
+        working-directory: frontend

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -1,4 +1,4 @@
-name: "Unit Tests"
+name: "Frontend Unit Tests"
 
 on:
   workflow_call:

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -22,4 +22,4 @@ jobs:
   test:
     name: Unit Tests
     if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' }}
-    uses: ./.github/workflows/unit-tests.yml
+    uses: ./.github/workflows/frontend-unit-tests.yml

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -1,4 +1,4 @@
-name: "Preview"
+name: "Unit Tests"
 
 on:
   pull_request:

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -1,0 +1,25 @@
+name: "Preview"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+
+concurrency:
+  group: unit-tests-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit Tests
+    if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,17 @@
+name: "Unit Tests"
+
+on:
+  workflow_call:
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "21.x"
+      - run: npm ci
+      - run: npm run test:unit


### PR DESCRIPTION
# What

This only runs the frontend unit tests

# Testing done

The tests have triggered on opening and reopening the PR

# Pending for future iterations

Out of scope:
- Backend unit tests
- [Trigger from comments](https://genlayer.slack.com/archives/C071DE6200M/p1719851490588059)
  - I'm still researching this approach to see if it's possible given that [some comments](https://github.com/orgs/community/discussions/25389#discussioncomment-8935283) mention it doesn't behave like PR checks