### PR TITLE
SIM-Pin ollama version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - "${WEBREQUESTPORT}"
 
   ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.2.1
     ports:
       - 11434:11434
     volumes:


### PR DESCRIPTION
# Why

Using `latest`:
- is not reproducible, which can lead to unexpected errors
- takes time to connect to dockerhub and check for new images

I think we should manually upgrade when necessary

# Motive

Downloading newer ollama images was slowing my dev flow