### PR TITLE
Hotfix: parse validator config from string

### DIFF
--- a/backend/database_handler/validators_registry.py
+++ b/backend/database_handler/validators_registry.py
@@ -19,7 +19,7 @@ class ValidatorsRegistry:
             "stake": float(validator_data["stake"]),
             "provider": validator_data["provider"],
             "model": validator_data["model"],
-            "config": validator_data["config"],
+            "config": json.loads(validator_data["config"]),
             "created_at": validator_data["created_at"].isoformat(),
         }
 


### PR DESCRIPTION
# Issue

While testing in staging prior to the release I was getting errors of the form

```
jsonrpc-1             | DBClient ~ ~ query: UPDATE transactions SET status = %s WHERE id = 13
jsonrpc-1             | DBClient ~ ~ params: ['PROPOSING']
jsonrpc-1             | DBClient ~ ~ query: SELECT * FROM current_state WHERE id = '0xA2Cd7eecAf8dfda72be4aBe5eB68bba96aF5b6dE' LIMIT 1
jsonrpc-1             | DBClient ~ ~ params: None
jsonrpc-1             | Error running contract 'str' object has no attribute 'items'
jsonrpc-1             | Traceback (most recent call last):
jsonrpc-1             |   File "/app/backend/node/base.py", line 76, in run_contract
jsonrpc-1             |     receipt = await self.genvm.run_contract(
jsonrpc-1             |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jsonrpc-1             |   File "/app/backend/node/genvm/base.py", line 121, in run_contract
jsonrpc-1             |     await function_to_run(*args)
jsonrpc-1             |   File "<string>", line 34, in ask_for_coin
jsonrpc-1             |   File "/app/backend/node/genvm/equivalence_principle.py", line 103, in call_llm_with_principle
jsonrpc-1             |     result = await eq.call_llm(prompt)
jsonrpc-1             |              ^^^^^^^^^^^^^^^^^^^^^^^^^
jsonrpc-1             |   File "/app/backend/node/genvm/equivalence_principle.py", line 72, in call_llm
jsonrpc-1             |     final_response = await llm_function(
jsonrpc-1             |                      ^^^^^^^^^^^^^^^^^^^
jsonrpc-1             |   File "/app/backend/node/genvm/llms.py", line 45, in call_ollama
jsonrpc-1             |     for name, value in model_config["config"].items():
jsonrpc-1             |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jsonrpc-1             | AttributeError: 'str' object has no attribute 'items'
jsonrpc-1             | 
jsonrpc-1             | DBClient ~ ~ query: UPDATE transactions SET status = %s WHERE id = 13
jsonrpc-1             | DBClient ~ ~ params: ['COMMITTING']
jsonrpc-1             | Error running contract 'NoneType' object is not subscriptable
jsonrpc-1             | Traceback (most recent call last):
jsonrpc-1             |   File "/app/backend/node/base.py", line 76, in run_contract
jsonrpc-1             |     receipt = await self.genvm.run_contract(
jsonrpc-1             |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jsonrpc-1             |   File "/app/backend/node/genvm/base.py", line 116, in run_contract
jsonrpc-1             |     leader_receipt_eq_result = leader_receipt["result"]["eq_outputs"]["leader"]
jsonrpc-1             |                                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
jsonrpc-1             | TypeError: 'NoneType' object is not subscriptable
jsonrpc-1             | 
jsonrpc-1             | Error running contract 'NoneType' object is not subscriptable
jsonrpc-1             | Traceback (most recent call last):
jsonrpc-1             |   File "/app/backend/node/base.py", line 76, in run_contract
jsonrpc-1             |     receipt = await self.genvm.run_contract(
jsonrpc-1             |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jsonrpc-1             |   File "/app/backend/node/genvm/base.py", line 116, in run_contract
jsonrpc-1             |     leader_receipt_eq_result = leader_receipt["result"]["eq_outputs"]["leader"]
jsonrpc-1             |                                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
jsonrpc-1             | TypeError: 'NoneType' object is not subscriptable
jsonrpc-1             | 
jsonrpc-1             | DBClient ~ ~ query: UPDATE transactions SET status = %s WHERE id = 13
jsonrpc-1             | DBClient ~ ~ params: ['REVEALING']
jsonrpc-1             | DBClient ~ ~ query: UPDATE transactions SET status = %s WHERE id = 13
jsonrpc-1             | DBClient ~ ~ params: ['ACCEPTED']
jsonrpc-1             | Error running consensus 'NoneType' object is not subscriptable
jsonrpc-1             | Traceback (most recent call last):
jsonrpc-1             |   File "/app/backend/consensus/base.py", line 71, in _run_consensus
jsonrpc-1             |     await asyncio.gather(*tasks)
jsonrpc-1             |   File "/app/backend/consensus/base.py", line 183, in exec_transaction
jsonrpc-1             |     leader_receipt["result"]["contract_state"]
jsonrpc-1             |     ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
jsonrpc-1             | TypeError: 'NoneType' object is not subscriptable
jsonrpc-1             | 
jsonrpc-1             | INFO | get_transaction_by_id: {'status': 'info', 'message': 'Starting...', 'data': {}}
jsonrpc-1             | DBClient ~ ~ query: SELECT * FROM transactions WHERE id = 13
```

This PR fixes those errors

# Origin

Seems like we had a problem in the data layer when parsing the config that was saved as a string in Postgres
