### PR TITLE
281 SIM-Clear Latest transactions 

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -69,7 +69,9 @@ class TransactionsProcessor:
     def get_transaction_by_id(self, transaction_id: int) -> dict:
         condition = f"id = {transaction_id}"
         transaction_data = self.db_client.get(self.db_transactions_table, condition)
-        return self._parse_transaction_data(transaction_data[0])
+        if(len(transaction_data) == 0):
+            return None
+        return self._parse_transaction_data(transaction_data)
 
     def update_transaction_status(
         self, transaction_id: int, new_status: TransactionStatus

--- a/frontend/src/plugins/persistStore.ts
+++ b/frontend/src/plugins/persistStore.ts
@@ -91,7 +91,7 @@ export function persistStorePlugin(context: PiniaPluginContext): void {
           case 'removeTransaction':
             await db.transactions
               .where('txId')
-              .equals(args[0] as string)
+              .equals((args[0] as any).id)
               .delete()
             break
           case 'updateTransaction':

--- a/frontend/src/plugins/transactionsListener.ts
+++ b/frontend/src/plugins/transactionsListener.ts
@@ -17,26 +17,34 @@ export const TransactionsListenerPlugin = {
 
       transactionsStore.processingQueue.push(...pendingTxs)
       if (transactionsStore.processingQueue.length > 0) {
-        const requests = transactionsStore.processingQueue.map((tx) =>
-          transactionsStore.getTransaction(tx.txId)
-        )
-        const results = await Promise.all(requests)
-        results.forEach((tx) => {
-          const currentTx = transactionsStore.processingQueue.find((t) => t.txId === tx?.data?.id)
-          transactionsStore.updateTransaction(tx?.data)
-          transactionsStore.processingQueue = transactionsStore.processingQueue.filter(
-            (t) => t.txId !== tx?.data?.id
-          )
-          // if finalized and is contract add to the contract store dpeloyed
-          if (tx?.data?.status === 'FINALIZED' && currentTx?.type === 'deploy') {
-            contractsStore.addDeployedContract({
-              contractId: currentTx.localContractId,
-              address: currentTx.contractAddress,
-              defaultState: '{}'
-            })
+
+        for (const item of transactionsStore.processingQueue) {
+          const tx = await transactionsStore.getTransaction(item.txId)
+          if (!tx?.data) {
+            // Remove the transaction from the processing queue and storage if not found
+            transactionsStore.processingQueue = transactionsStore.processingQueue.filter(
+              (t) => t.txId !== item.txId
+            )
+            transactionsStore.removeTransaction(item)
+          } else {
+            const currentTx = transactionsStore.processingQueue.find((t) => t.txId === tx?.data?.id)
+            transactionsStore.updateTransaction(tx?.data)
+            transactionsStore.processingQueue = transactionsStore.processingQueue.filter(
+              (t) => t.txId !== tx?.data?.id
+            )
+            // if finalized and is contract add to the contract store dpeloyed
+            if (tx?.data?.status === 'FINALIZED' && currentTx?.type === 'deploy') {
+              contractsStore.addDeployedContract({
+                contractId: currentTx.localContractId,
+                address: currentTx.contractAddress,
+                defaultState: '{}'
+              })
+            }
           }
-        })
-        console.log(`There are ${pendingTxs.length} pending transactions`, results)
+         
+        }
+        
+        console.log(`There are ${pendingTxs.length} pending transactions`)
       }
     }
     setInterval(listener, interval)


### PR DESCRIPTION
This PR includes a fix for a issue when we try to get a non existing transaction

Steps to reproduce the issue:
- Create a few transactions in the simulator and stop the backend containers to keep the transactions in status PENDING
- Keep the front end running and recreate the rpc and Postgres container
- Reload the browser and then we have some transactions in the browser storage that will be used to get the transaction in the backend, then it will throw an error

After the fix:
We return `None` from the backend if the transaction not exists and then clear in the browser storage 