### PR TITLE
265 sim gh action to run e2e tests on pr open and approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,7 @@ OPENAIKEY           = '<add_your_openai_api_key_here>'
 HEURISTAIURL        = 'https://llm-gateway.heurist.xyz'
 HEURISTAIMODELSURL  = 'https://raw.githubusercontent.com/heurist-network/heurist-models/main/models.json'
 # If you want to use Heurist AI add your key here
-HEURISTAIAPIKEY     = '<add_your_api_key_here>'
+HEURISTAIAPIKEY     = '<add_your_heuristai_api_key_here>'
 
 # Front end container details
 VITE_JSON_RPC_SERVER_URL  = 'http://127.0.0.1:4000/api'

--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ WEBREQUESTHOST      = 'webrequest'
 WEBREQUESTPORT      = '5000'
 
 # If you want to use OpenAI add your key here
-OPENAIKEY           = '<add_your_api_key_here>'
+OPENAIKEY           = '<add_your_openai_api_key_here>'
 
 # Heurist AI Details
 HEURISTAIURL        = 'https://llm-gateway.heurist.xyz'

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set OPENAIKEY in the .env file so it can be loaded from the environment
         env:
           OPENAIKEY: ${{ secrets.OPENAIKEY }}
-        run: sed -i "/<add_your_openai_api_key_here>/${OPENAIKEY}/g" .env
+        run: sed -i "s/<add_your_openai_api_key_here>/${OPENAIKEY}/g" .env
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - staging
     types:
       - opened
       - synchronize

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -7,6 +7,7 @@ on:
     types:
       - opened
       - synchronize
+      - edited
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
+    branches:
+      - staging
     types:
       - opened
-      - synchronize
-      - edited
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -6,6 +6,7 @@ on:
       - staging
     types:
       - opened
+      - synchronize
   pull_request_review:
     types:
       - submitted

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -25,16 +25,10 @@ jobs:
       - name: Copy .env file
         run: cp .env.example .env
 
-      - name: Changing URL for rpc server to localhost
-        run: sed -i "s/'jsonrpc'/'localhost'/g" .env
-      
-      - name: Remove OPENAIKEY from the .env file so it can be loaded from the environment
-        run: sed -i "/^OPENAIKEY *= *'<add_your_api_key_here>'$/d" .env
-
-      - name: Adding OPENAIKEY to the .env file
+      - name: Set OPENAIKEY in the .env file so it can be loaded from the environment
         env:
           OPENAIKEY: ${{ secrets.OPENAIKEY }}
-        run: printf "\nOPENAIKEY='$OPENAIKEY'\n" >> .env
+        run: sed -i "/<add_your_openai_api_key_here>/${OPENAIKEY}/g" .env
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -6,7 +6,6 @@ on:
       - staging
     types:
       - opened
-      - synchronize
   pull_request_review:
     types:
       - submitted

--- a/backend/node/create_nodes/create_nodes.py
+++ b/backend/node/create_nodes/create_nodes.py
@@ -19,7 +19,7 @@ def base_node_json(provider: str, model: str) -> dict:
     return {"provider": provider, "model": model, "config": {}}
 
 
-def get_random_provider_using_weights(defaults):
+def get_random_provider_using_weights(defaults: dict) -> str:
     # remove providers if no api key
     provider_weights = defaults["provider_weights"]
     if "openai" in provider_weights and (
@@ -32,7 +32,7 @@ def get_random_provider_using_weights(defaults):
         or os.environ["HEURISTAIAPIKEY"] == default_provider_key_value
     ):
         provider_weights.pop("heuristai")
-    if get_provider_models({}, "ollama") == []:
+    if "ollama" in provider_weights and get_provider_models({}, "ollama") == []:
         provider_weights.pop("ollama")
 
     if len(provider_weights) == 0:

--- a/backend/node/create_nodes/create_nodes.py
+++ b/backend/node/create_nodes/create_nodes.py
@@ -116,7 +116,9 @@ def num_decimal_places(number: float) -> int:
     return decimal_places
 
 
-def random_validator_config(providers: list = []):
+def random_validator_config(providers: list = None):
+    providers = providers or []
+
     if len(providers) == 0:
         providers = get_providers()
     default_config = get_default_config_for_providers_and_nodes()

--- a/backend/node/create_nodes/create_nodes.py
+++ b/backend/node/create_nodes/create_nodes.py
@@ -48,7 +48,7 @@ def get_random_provider_using_weights(defaults):
             return key
 
 
-def get_provider_models(defaults: str, provider: str) -> list:
+def get_provider_models(defaults: dict, provider: str) -> list:
 
     if provider == "ollama":
         ollama_models_result = requests.get(get_ollama_url("tags")).json()

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -265,8 +265,10 @@ def create_random_validators(
     count: int,
     min_stake: int,
     max_stake: int,
-    providers: list = [],
+    providers: list = None,
 ) -> dict:
+    providers = providers or []
+
     for _ in range(count):
         stake = random.uniform(min_stake, max_stake)
         validator_address = create_new_address()

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -266,6 +266,8 @@ def create_random_validators(
     min_stake: int,
     max_stake: int,
     providers: list = None,
+    fixed_provider: str = None,
+    fixed_model: str = None,
 ) -> dict:
     providers = providers or []
 
@@ -276,8 +278,8 @@ def create_random_validators(
         new_validator = validators_registry.create_validator(
             validator_address,
             stake,
-            details["provider"],
-            details["model"],
+            fixed_provider or details["provider"],
+            fixed_model or details["model"],
             details["config"],
         )
         if not "id" in new_validator:

--- a/tests/integration/test_football_prediction_market.py
+++ b/tests/integration/test_football_prediction_market.py
@@ -21,7 +21,7 @@ from tests.common.response import (
 def test_football_prediction_market():
     # Validators Setup
     result = post_request_localhost(
-        payload("create_random_validators", 5, 8, 12, ["openai"])
+        payload("create_random_validators", 5, 8, 12, ["openai"], None, "gpt-3.5-turbo")
     ).json()
     assert has_success_status(result)
 

--- a/tests/integration/test_llm_erc20.py
+++ b/tests/integration/test_llm_erc20.py
@@ -24,7 +24,7 @@ TRANSFER_AMOUNT = 100
 def test_llm_erc20():
     # Validators Setup
     result = post_request_localhost(
-        payload("create_random_validators", 5, 8, 12, ["openai"])
+        payload("create_random_validators", 5, 8, 12, ["openai"], None, "gpt-3.5-turbo")
     ).json()
     assert has_success_status(result)
 

--- a/tests/integration/test_storage.py
+++ b/tests/integration/test_storage.py
@@ -24,7 +24,9 @@ UPDATED_STATE = "b"
 def test_storage():
     # Validators Setup
     result = post_request_localhost(
-        payload("create_random_validators", 10, 8, 12, ["openai"])
+        payload(
+            "create_random_validators", 10, 8, 12, ["openai"], None, "gpt-3.5-turbo"
+        )
     ).json()
     assert has_success_status(result)
 

--- a/tests/integration/test_user_storage.py
+++ b/tests/integration/test_user_storage.py
@@ -26,7 +26,9 @@ UPDATED_STATE_USER_B = "user_b_updated_state"
 def test_user_storage():
     # Validators Setup
     result = post_request_localhost(
-        payload("create_random_validators", 10, 8, 12, ["openai"])
+        payload(
+            "create_random_validators", 10, 8, 12, ["openai"], None, "gpt-3.5-turbo"
+        )
     ).json()
     assert has_success_status(result)
 

--- a/tests/integration/test_wizard_of_coin.py
+++ b/tests/integration/test_wizard_of_coin.py
@@ -22,7 +22,9 @@ def test_wizard_of_coin():
     print("test_wizard_of_coin")
     # Validators
     result = post_request_localhost(
-        payload("create_random_validators", 10, 8, 12, ["openai"])
+        payload(
+            "create_random_validators", 10, 8, 12, ["openai"], None, "gpt-3.5-turbo"
+        )
     ).json()
     assert has_success_status(result)
 


### PR DESCRIPTION
fixes https://github.com/yeagerai/genlayer-simulator/issues/265

# What

- fixes e2e tests: the main reason was that we were trying to `pop` the `ollama` provider when there wasn't any in the list 
- sets gpt-3.5 as the model to use for e2e tests: this is because its way cheaper
- other small changes done along the way to keep improving the codebase little by little, following the "[boy scout rule](https://biratkirat.medium.com/step-8-the-boy-scout-rule-robert-c-martin-uncle-bob-9ac839778385)"

# Why

e2e tests were failing

# Testing done

e2e tests are passing in this branch

https://github.com/yeagerai/genlayer-simulator/actions/runs/9962830784