### PR TITLE
SIM-OPS-Build and Push docker images on releases

### DIFF
--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -1,0 +1,60 @@
+name: "Docker build and push to Docker Hub"
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  jsonrpc:
+    uses: ./.github/workflows/docker-build-and-push-image.yml
+    with:
+      docker_build_context: .
+      dockerfile: docker/Dockerfile.backend
+      dockerhub_repo: yeagerai/simulator-jsonrpc
+      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  frontend:
+    uses: ./.github/workflows/docker-build-and-push-image.yml
+    with:
+      docker_build_context: .
+      dockerfile: docker/Dockerfile.frontend
+      dockerhub_repo: yeagerai/simulator-frontend
+      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  webrequest:
+    uses: ./.github/workflows/docker-build-and-push-image.yml
+    with:
+      docker_build_context: .
+      dockerfile: docker/Dockerfile.webrequest
+      dockerhub_repo: yeagerai/simulator-webrequest
+      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  database:
+    uses: ./.github/workflows/docker-build-and-push-image.yml
+    with:
+      docker_build_context: .
+      dockerfile: docker/Dockerfile.database
+      dockerhub_repo: yeagerai/simulator-database
+      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  database-migration:
+    uses: ./.github/workflows/docker-build-and-push-image.yml
+    with:
+      docker_build_context: backend/database_handler
+      dockerfile: docker/Dockerfile.database-migration
+      dockerhub_repo: yeagerai/simulator-database-migration
+      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
+    secrets:
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -1,0 +1,78 @@
+name: "Docker build and push to Docker Hub"
+
+on:
+  workflow_call:
+    inputs:
+      docker_build_context:
+        required: true
+        type: string
+        default: .
+      dockerfile:
+        required: true
+        type: string
+        default: Dockerfile
+      dockerhub_repo:
+        required: true
+        type: string
+      dockerhub_username:
+        required: true
+        type: string
+    secrets:
+      dockerhub_token:
+        required: true
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  build_and_push_backend:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # TODO: Once we have the 1Password service account token, we can use the following action to load secrets
+      # "better done than perfect"
+
+      # - name: Load secrets from 1Password
+      #   uses: 1password/load-secrets-action/configure@v1
+      #   id: op-load-secret
+      #   with:
+      #     service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      #   env:
+      #     DOCKERHUB_USERNAME:
+      #     DOCKERHUB_TOKEN:
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.dockerhub_username }}
+          password: ${{ secrets.dockerhub_token }}
+          # username: ${{ steps.op-load-secret.outputs.DOCKERHUB_USERNAME }}
+          # password: ${{ steps.op-load-secret.outputs.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # jsonrpc
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ inputs.dockerhub_repo }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.docker_build_context }}
+          file: ${{ inputs.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -79,3 +79,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-and-push-image.yml
+++ b/.github/workflows/docker-build-and-push-image.yml
@@ -54,6 +54,9 @@ jobs:
           # username: ${{ steps.op-load-secret.outputs.DOCKERHUB_USERNAME }}
           # password: ${{ steps.op-load-secret.outputs.DOCKERHUB_TOKEN }}
 
+      - name: Create .env file
+        run: cp .env.example .env
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #319 

# What

<!-- Describe the changes you made. -->

- Added GH Action to build and push docker images of all services

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

For Nakima and future use for end users

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

Manually created test tag:
- the GH Action ran correctly https://github.com/yeagerai/genlayer-simulator/actions/runs/10062488454
- the images are pushed in the registry https://hub.docker.com/repositories/yeagerai?search=simulator

# Decisions made

- I've separated the workflow to be reusable for each service
- For now we are creating an image for the postgres database, which is really a small wrapper of `postgres`. In the future I think we should directly use `postgres` and configure it through volumes and envvars. Having our own thin wrapper is not very useful

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set the PR name to the issue name

# Reviewing tips

Check out the links in the testing section

# User facing release notes

Container images for all services are now available at [our DockerHub](https://hub.docker.com/u/yeagerai)
- https://hub.docker.com/repository/docker/yeagerai/simulator-webrequest/general
- https://hub.docker.com/repository/docker/yeagerai/simulator-frontend/general
- https://hub.docker.com/repository/docker/yeagerai/simulator-jsonrpc/general
- https://hub.docker.com/repository/docker/yeagerai/simulator-database/general
- https://hub.docker.com/repository/docker/yeagerai/simulator-database-migration/general
