### PR TITLE
SIM-GH checks to block PRs from merging when tests don't pass #293

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     types:
       - opened
-      - ready_for_review
+      - labeled
+      - synchronize
   pull_request_review:
     types:
       - submitted
-  issue_comment:
-    types: created
+      - edited
 
 concurrency:
   group: backend-e2e-${{ github.event.number }}
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && github.base_ref == 'staging') || (github.event.issue.pull_request && (github.event.comment.body == '/test-unit' || github.event.comment.body == '/test')) }}
+    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -23,7 +23,8 @@ jobs:
       is_pull_request_opened: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
       is_pull_request_review_approved: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'}}
       is_pull_request_labeled_with_run_tests: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')}}
-
+    steps:
+      - run: true
   test:
     needs: triggers
     if: ${{ needs.triggers.outputs.is_pull_request_opened || needs.triggers.outputs.is_pull_request_review_approved || needs.triggers.outputs.is_pull_request_labeled_with_run_tests }}

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -8,11 +8,16 @@ on:
   pull_request_review:
     types:
       - submitted
-  workflow_dispatch:
+  issue_comment:
+    types: created
+
+concurrency:
+  group: backend-e2e-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   test:
-    if: ${{ github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && github.base_ref == 'staging') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && github.base_ref == 'staging') || (github.event.issue.pull_request && (github.event.comment.body == '/test-unit' || github.event.comment.body == '/test')) }}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -16,8 +16,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  triggers:
+    name: Get Triggers
+    runs-on: ubuntu-latest
+    outputs:
+      is_pull_request_opened: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
+      is_pull_request_review_approved: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'}}
+      is_pull_request_labeled_with_run_tests: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')}}
+
   test:
-    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
+    needs: triggers
+    if: ${{ needs.triggers.outputs.is_pull_request_opened || needs.triggers.outputs.is_pull_request_review_approved || needs.triggers.outputs.is_pull_request_labeled_with_run_tests }}
+
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -6,12 +6,12 @@ on:
       - opened
       - ready_for_review
       - reopened
+      - labeled
+      - synchronize
   pull_request_review:
     types:
       - submitted
       - edited
-  issue_comment:
-    types: created
   push:
     branches: main
 
@@ -25,7 +25,7 @@ permissions:
 jobs:
   test:
     name: Unit Tests
-    if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' || (github.event.issue.pull_request && (github.event.comment.body == '/test-unit' || github.event.comment.body == '/test')) }}
+    if: ${{ github.event.pull_request.state == 'opened' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -4,16 +4,12 @@ on:
   pull_request:
     types:
       - opened
-      - ready_for_review
-      - reopened
       - labeled
       - synchronize
   pull_request_review:
     types:
       - submitted
       - edited
-  push:
-    branches: main
 
 concurrency:
   group: unit-tests-${{ github.event.number }}
@@ -25,14 +21,14 @@ permissions:
 jobs:
   test:
     name: Unit Tests
-    if: ${{ github.event.pull_request.state == 'opened' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   load-test:
     name: Load Tests
-    if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
     uses: ./.github/workflows/load-test-oha.yml
     with:
       oha-version: "v1.4.5"

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -10,6 +10,8 @@ on:
     types:
       - submitted
       - edited
+  issue_comment:
+    types: created
   push:
     branches: main
 
@@ -23,7 +25,7 @@ permissions:
 jobs:
   test:
     name: Unit Tests
-    if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' || (github.event.issue.pull_request && (github.event.comment.body == '/test-unit' || github.event.comment.body == '/test')) }}
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -33,4 +35,4 @@ jobs:
     if: ${{ github.event.review.state == 'APPROVED' || github.event_name == 'pull_request' }}
     uses: ./.github/workflows/load-test-oha.yml
     with:
-      oha-version: 'v1.4.5'
+      oha-version: "v1.4.5"

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -21,14 +21,14 @@ permissions:
 jobs:
   test:
     name: Unit Tests
-    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   load-test:
     name: Load Tests
-    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || contains(github.event.pull_request.labels.*.name, 'run-tests') }}
+    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
     uses: ./.github/workflows/load-test-oha.yml
     with:
       oha-version: "v1.4.5"

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -26,7 +26,8 @@ jobs:
       is_pull_request_opened: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
       is_pull_request_review_approved: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'}}
       is_pull_request_labeled_with_run_tests: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')}}
-
+    steps:
+      - run: true
   test:
     name: Unit Tests
     needs: triggers

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -19,16 +19,26 @@ permissions:
   contents: read
 
 jobs:
+  triggers:
+    name: Get Triggers
+    runs-on: ubuntu-latest
+    outputs:
+      is_pull_request_opened: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
+      is_pull_request_review_approved: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'}}
+      is_pull_request_labeled_with_run_tests: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')}}
+
   test:
     name: Unit Tests
-    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
+    needs: triggers
+    if: ${{ needs.triggers.outputs.is_pull_request_opened || needs.triggers.outputs.is_pull_request_review_approved || needs.triggers.outputs.is_pull_request_labeled_with_run_tests }}
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   load-test:
     name: Load Tests
-    if: ${{ github.event.pull_request.state == 'opened' || github.event.review.state == 'APPROVED' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')) }}
+    needs: triggers
+    if: ${{ needs.triggers.outputs.is_pull_request_opened || needs.triggers.outputs.is_pull_request_review_approved || needs.triggers.outputs.is_pull_request_labeled_with_run_tests }}
     uses: ./.github/workflows/load-test-oha.yml
     with:
       oha-version: "v1.4.5"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ $ docker compose up
 1. Installing the Ollama model
 
    ```
-   $ docker exec -it ollama ollama run llama3
+   $ docker exec ollama ollama pull llama3
    ```
 
 2. Setup your environment
@@ -94,6 +94,15 @@ We strive to maintain high-quality code and ensure that all contributions align 
 - **Automated Tests**: Your PR will automatically be tested. Ensure all tests pass to proceed.
 - **Peer Review**: One or more core contributors will review your PR. They may suggest changes or improvements.
 - **Approval and Merge**: After approval from the reviewers, your PR will be merged into the project.
+
+### PR Checks
+
+On PRs we have the following checks:
+
+- Backend end-to-end tests
+- Frontend unit tests
+
+These will be run automatically when you open a PR (and would need an approval from a maintainer if you are not a maintainer). If you modify your PR afterwards, you'll need to manually run the checks again by commenting `/test` on the PR.
 
 ## Community
 


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Part of https://github.com/yeagerai/genlayer-simulator/issues/293

# What

<!-- Describe the changes you made. -->

- Triggering tests through PR with labels `run-tests`
- I've also created the ruleset https://github.com/yeagerai/genlayer-simulator/settings/rules/1192424
  - I'll enable this ruleset once this PR gets merged
 
# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

In order to add checks for PRs, these checks need to be ran in the last commit of the PR (if not they are skipped, which could come as false negatives). In order to allow manual triggering of them for certain cases (like when modifications occur in the PR) I've added the functionality to trigger them with comments

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- I'll add a comment to this PR to test it

# Decisions made

The decision of using comments was done through slack

# Checks

- [x] I have tested this code
- [ ] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set the PR name to the issue name

