### PR TITLE
334 SIM-generate releases and versions when merging to main

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -1,0 +1,25 @@
+name: Changelog
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-main:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Depends on the following format from the commit message:
+      # Release vX.Y.Z ...
+      #
+      # Release notes here
+      # ...
+      - name: Create release
+        run: |
+          commit_msg=$(git log -1 --pretty=%B)
+          semver=$(echo $commit_msg | head -n -1 | awk '{print $2}')
+          echo $commit_msg | tail -n +3 > body.txt
+          gh release create $semver --title $semver -F body.txt --prerelease
+        # TODO: remove prerelease flag after testing            ^^^^^^^^^^^^
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #https://github.com/yeagerai/genlayer-simulator/issues/334

# What

<!-- Describe the changes you made. -->

- Automatically creates GH Releases from `main` branch

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to automate a manual task

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Manually called `gh release create $semver --title $semver -F body.txt --prerelease` locally and it worked as expected

# Decisions made

I've left the `prerelease` flag since I don't have a way to test this end to end. Once we see that it works as expected I'll remove it

# Checks

- [ ] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set the PR name to the issue name

# Reviewing tips

This PR depends on a specific format from the commits, which will go in combo with https://github.com/yeagerai/genlayer-simulator/pull/335


