### PR TITLE
314 sim   removed transactions are restored after adds new transaction

### DIFF
--- a/frontend/src/plugins/persistStore.ts
+++ b/frontend/src/plugins/persistStore.ts
@@ -119,7 +119,7 @@ export function persistStorePlugin(context: PiniaPluginContext): void {
           case 'removeTransaction':
             await db.transactions
               .where('txId')
-              .equals((args[0] as any).id)
+              .equals((args[0] as any).txId)
               .delete();
             break;
           case 'updateTransaction':

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -88,12 +88,16 @@ const handleDeployContract = async ({
 };
 
 const handleClearTransactions = () => {
-  transactionsStore.processingQueue = transactionsStore.processingQueue.filter(
-    (t) => t.localContractId !== contractsStore.currentContractId,
-  );
-  transactionsStore.transactions = transactionsStore.transactions.filter(
-    (t) => t.localContractId !== contractsStore.currentContractId,
-  );
+  transactionsStore.processingQueue.forEach((t) => {
+    if (t.localContractId === contractsStore.currentContractId) {
+      transactionsStore.removeTransaction(t);
+    }
+  });
+  transactionsStore.transactions.forEach((t) => {
+    if (t.localContractId === contractsStore.currentContractId) {
+      transactionsStore.removeTransaction(t);
+    }
+  });
 };
 
 const debouncedGetConstructorInputs = debounce(


### PR DESCRIPTION
Fixes #314 

# What

- Used store actions instead of direct store change to trigger persist plugin.
- Fixed local db query param to map to correct property.

# Why

This was an issue where the removal of transactions was not actually persisted in the local db. Deploying a new contract was simply displaying the symptom; reloading after deleting the TXs was also yielding the same result: transactions always re-appeared after removal.

# Testing done

- tested the bug fix

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set the PR name to the issue name

# User facing release notes

- Fixed an issue were transactions were re-appearing after being cleared.
