### PR TITLE
366-sim-be-reduce-docker-image-by-sentence-transformers-python-package-size-optimization

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12.5
+          python-version: 3.12.4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Copy .env file
         run: cp .env.example .env
@@ -48,10 +48,10 @@ jobs:
         run: sed -i "s/<add_your_openai_api_key_here>/${OPENAIKEY}/g" .env
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -86,9 +86,9 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.12.4
+          python-version: 3.12.5
 
       - name: Install dependencies
         run: |

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,12 +1,13 @@
-FROM python:3.12.2-slim AS base
+FROM python:3.12.5-slim AS base
 
 ARG path=/app
 
-RUN mkdir $path
 WORKDIR $path
 
 ADD backend/protocol_rpc/requirements.txt backend/protocol_rpc/requirements.txt
-RUN pip install --no-cache-dir -r backend/protocol_rpc/requirements.txt
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir -r backend/protocol_rpc/requirements.txt
 
 ENV PYTHONPATH "${PYTHONPATH}:/${path}"
 ENV FLASK_APP=backend/protocol_rpc/server.py
@@ -24,5 +25,5 @@ CMD watchmedo auto-restart --recursive --pattern="*.py" --ignore-patterns="*.pyc
 
 ###########START NEW IMAGE: PRODUCTION ###################
 FROM base AS prod
-
+USER backend-user
 CMD flask run -h 0.0.0.0 -p ${FLASK_SERVER_PORT}

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,7 +1,6 @@
 FROM python:3.12.5-slim AS base
 
 ARG path=/app
-
 WORKDIR $path
 
 ADD backend/protocol_rpc/requirements.txt backend/protocol_rpc/requirements.txt

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -9,10 +9,15 @@ RUN pip install --upgrade pip \
     && pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
     && pip install --no-cache-dir -r backend/protocol_rpc/requirements.txt
 
+RUN groupadd -r backend-group \
+    && useradd -r -g backend-group backend-user \
+    && mkdir -p /home/backend-user/.cache/huggingface \
+    && chown -R backend-user:backend-group /home/backend-user \
+    && chown -R backend-user:backend-group $path
+
 ENV PYTHONPATH "${PYTHONPATH}:/${path}"
 ENV FLASK_APP=backend/protocol_rpc/server.py
-RUN groupadd -r backend-user && useradd -r -g backend-user backend-user \
-    && chown -R backend-user:backend-user $path
+ENV TRANSFORMERS_CACHE=/home/backend-user/.cache/huggingface
 
 COPY ../.env .
 COPY backend $path/backend

--- a/docker/Dockerfile.database-migration
+++ b/docker/Dockerfile.database-migration
@@ -1,4 +1,4 @@
-FROM python:3.12.2-slim
+FROM python:3.12.5-slim
 
 WORKDIR /app
 

--- a/docker/Dockerfile.webrequest
+++ b/docker/Dockerfile.webrequest
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.12-slim
+FROM --platform=linux/amd64 python:3.12.5-slim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget gnupg && \


### PR DESCRIPTION
Fixes #366

# What
- reduce backend docker image
- set PyTorch to CPU only, without NVIDIA CUDA
- also updated Python to 3.12.5

# Why
- optimize backend docker image size from 5,77GB to 1.48GB
- to fix failing CI due to no disk space left error

# Testing done

- tested the fix locally
