### PR TITLE
fix: use relative path for import on tutorial contract

### DIFF
--- a/frontend/src/stores/tutorial.ts
+++ b/frontend/src/stores/tutorial.ts
@@ -3,6 +3,7 @@ import { useContractsStore } from './contracts';
 import { useNodeStore } from './node';
 import { useTransactionsStore } from './transactions';
 import { useMockContractData } from '@/hooks/useMockContractData';
+import contractBlob from '@/assets/examples/contracts/storage.py?raw';
 
 const { mockContractId, mockDeployedContract, mockDeploymentTx } =
   useMockContractData();
@@ -130,14 +131,10 @@ export const useTutorialStore = defineStore('tutorialStore', () => {
   };
 
   async function addAndOpenContract() {
-    const contractBlob = await import(
-      '../assets/examples/contracts/storage.py?raw'
-    );
-
     const contractFile = {
       id: mockContractId,
       name: 'tutorial_storage.py',
-      content: ((contractBlob.default as string) || '').trim(),
+      content: ((contractBlob as string) || '').trim(),
       example: true,
     };
 

--- a/frontend/src/stores/tutorial.ts
+++ b/frontend/src/stores/tutorial.ts
@@ -131,7 +131,7 @@ export const useTutorialStore = defineStore('tutorialStore', () => {
 
   async function addAndOpenContract() {
     const contractBlob = await import(
-      '@/assets/examples/contracts/storage.py?raw'
+      '../assets/examples/contracts/storage.py?raw'
     );
 
     const contractFile = {


### PR DESCRIPTION
Could POTENTIALLY FIX #380 

# What

- used a relative import path without '@' alias


# Why

To fix unit tests failing in GH

# Testing done

Can't test this locally


# Reviewing tips

Need to see if unit tests now pass.
