### PR TITLE
ci: gh action to validate pr title 

### DIFF
--- a/.github/workflows/conventional-commit-pr.yml
+++ b/.github/workflows/conventional-commit-pr.yml
@@ -1,0 +1,15 @@
+name: PR Conventional Commit Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [staging]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses: ytanikin/PRConventionalCommits@1.2.0
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'

--- a/.github/workflows/conventional-commit-pr.yml
+++ b/.github/workflows/conventional-commit-pr.yml
@@ -13,3 +13,4 @@ jobs:
         uses: ytanikin/PRConventionalCommits@1.2.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: "false"

--- a/.github/workflows/only-merge-release-branches-to-main.yml
+++ b/.github/workflows/only-merge-release-branches-to-main.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches:
       - main
+      - staging
 
 jobs:
   validate-pr-source-branch:
@@ -12,10 +13,14 @@ jobs:
     steps:
       - name: Check if source branch is a release branch
         run: |
+          if [[ ${{ github.event.pull_request.base.ref }} == "staging" ]]; then
+              echo "Target branch is staging"
+              exit 0
+          fi
           if [[ ${{ github.event.pull_request.head.ref }} =~ ^release/.*$ ]]; then
-            echo "Source branch is a release branch"
-            exit 0
+              echo "Source branch is a release branch"
+              exit 0
           else
-            echo "Source branch is not a release branch"
-            exit 1
+              echo "Source branch is not a release branch"
+              exit 1
           fi

--- a/.github/workflows/only-merge-release-branches-to-main.yml
+++ b/.github/workflows/only-merge-release-branches-to-main.yml
@@ -1,0 +1,21 @@
+name: Only merge release branches to main
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches:
+      - main
+
+jobs:
+  validate-pr-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if source branch is a release branch
+        run: |
+          if [[ ${{ github.event.pull_request.head.ref }} =~ ^release/.*$ ]]; then
+            echo "Source branch is a release branch"
+            exit 0
+          else
+            echo "Source branch is not a release branch"
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,12 +39,6 @@ repos:
         entry: sh -c "cd frontend && npm run format"
         language: system
         files: frontend
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.4.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-        args: []
 
 default_install_hook_types:
   - pre-commit


### PR DESCRIPTION
Fixes #423 

# What

- adds a GH action 

As @cristiam86 mentioned, we might be able to then use https://github.com/marketplace/actions/changelog-from-conventional-commits to create release notes

# Why

To adhere with our contributing standard

# Testing done

- pointing the PR to main doesn't trigger the workflow (needed for release PRs which are not following conventional commits)
- action has run correctly on this PR

# Decisions made

- I've used https://github.com/ytanikin/PRConventionalCommits since it seemed to be the most maintained and with nice features
- I've removed the pre-commit hook to check conventional commits: since we are squash merging we are only interested in the PR title check

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set the PR name to the issue name
