### PR TITLE
fix: 409 sim fe alow horizontal scroll when there is syntax error in the contract

### DIFF
--- a/frontend/src/components/Simulator/CodeEditor.vue
+++ b/frontend/src/components/Simulator/CodeEditor.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import { ref, shallowRef, watch, computed } from 'vue';
 import { pythonSyntaxDefinition } from '@/utils';
+import { ref, shallowRef, watch, computed, onMounted } from 'vue';
 import { useContractsStore, useUIStore } from '@/stores';
 import { type ContractFile } from '@/types';
 
@@ -16,33 +16,29 @@ const containerElement = ref<HTMLElement | null | undefined>(null);
 const editorRef = shallowRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 const theme = computed(() => (uiStore.mode === 'light' ? 'vs' : 'vs-dark'));
 
-watch(
-  () => editorElement.value,
-  (newValue) => {
-    if (!editorRef.value && newValue) {
-      containerElement.value = editorElement.value?.parentNode?.parentElement;
-      monaco.languages.register({ id: 'python' });
-      monaco.languages.setMonarchTokensProvider(
-        'python',
-        pythonSyntaxDefinition,
-      );
-      editorRef.value = monaco.editor.create(editorElement.value!, {
-        value: props.contract.content || '',
-        language: 'python',
-        theme: theme.value,
-        automaticLayout: true,
-        formatOnPaste: true,
-        formatOnType: true,
-      });
-      editorRef.value.onDidChangeModelContent(() => {
-        contractStore.updateContractFile(props.contract.id!, {
-          content: editorRef.value?.getValue() || '',
-          updatedAt: new Date().toISOString(),
-        });
-      });
-    }
-  },
-);
+function initEditor() {
+  containerElement.value = editorElement.value?.parentElement;
+  monaco.languages.register({ id: 'python' });
+  monaco.languages.setMonarchTokensProvider('python', pythonSyntaxDefinition);
+  editorRef.value = monaco.editor.create(editorElement.value!, {
+    value: props.contract.content || '',
+    language: 'python',
+    theme: theme.value,
+    automaticLayout: true,
+    formatOnPaste: true,
+    formatOnType: true,
+  });
+  editorRef.value.onDidChangeModelContent(() => {
+    contractStore.updateContractFile(props.contract.id!, {
+      content: editorRef.value?.getValue() || '',
+      updatedAt: new Date().toISOString(),
+    });
+  });
+}
+
+onMounted(() => {
+  initEditor();
+});
 
 watch(
   () => uiStore.mode,

--- a/frontend/src/components/Simulator/ConstructorParameters.vue
+++ b/frontend/src/components/Simulator/ConstructorParameters.vue
@@ -119,7 +119,7 @@ const mapInputs = (inputs: { [k: string]: string }) =>
 watch(
   () => constructorInputs.value,
   (newValue) => {
-    setInputParams(newValue || {});
+    setInputParams(newValue || []);
   },
 );
 

--- a/frontend/src/components/Simulator/ContractsPanel.vue
+++ b/frontend/src/components/Simulator/ContractsPanel.vue
@@ -85,19 +85,21 @@ const handleHorizontalScroll = (event: WheelEvent) => {
     <HomeTab v-show="showHome" />
 
     <div
-      v-if="!!error"
-      class="left-O right-O absolute bottom-0 z-10 w-full bg-red-500 px-2 py-1 text-sm text-white"
-    >
-      {{ error }}
-    </div>
-
-    <div
       v-for="contract in contracts"
       :key="contract.id"
-      class="relative flex h-full w-full"
+      class="relative flex h-full w-full flex-col overflow-hidden"
       v-show="contract.id === store.currentContractId"
     >
-      <CodeEditor :contract="contract" @run-debug="handleRunDebug" />
+      <div class="flex h-full w-full grow overflow-hidden">
+        <CodeEditor :contract="contract" @run-debug="handleRunDebug" />
+      </div>
+
+      <div
+        v-if="!!error"
+        class="w-full shrink-0 bg-red-500 px-2 py-1 text-sm text-white"
+      >
+        {{ error }}
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
fixes #409 

# What

- Fixed an issue with layout / resizing of the editor, which was causing an overlap between scrollbar and error notice
- Fixed a watcher that caused error in constructor inputs

# Why

- to fix a bug

# Testing done

- lint OK
- e2e OK
- unit OK
- tested the fix

# Decisions made

- Moved the code editor initialization to a proper function instead of a watcher

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set the PR name to the issue name


# User facing release notes

- Fixed an issue where the syntax error notice was overlapping the horizontal scrollbar in the editor