### PR TITLE
feat(fe): proxy to jsonrpc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,8 +60,14 @@ HEURISTAIAPIKEY     = '<add_your_heuristai_api_key_here>'
 # ANTHROPIC_API_KEY   = '<add_your_anthropic_api_key_here>'
 
 # Front end container details
-VITE_JSON_RPC_SERVER_URL  = 'http://127.0.0.1:4000/api'
-VITE_WS_SERVER_URL   = 'ws://127.0.0.1:4000'
+VITE_JSON_RPC_SERVER_URL  = 'http://127.0.0.1:4000/api' # if VITE_PROXY_ENABLED = 'true' change to '/api'
+VITE_WS_SERVER_URL   = 'ws://127.0.0.1:4000' # if VITE_PROXY_ENABLED = 'true' change to '/'
 VITE_PLAUSIBLE_DOMAIN = 'simulator.genlayer.com'
 FRONTEND_PORT   = '8080'
+FRONTEND_BUILD_TARGET = 'final' # change to 'dev' to run in dev mode
+
+VITE_PROXY_ENABLED = 'false'
+VITE_PROXY_JSON_RPC_SERVER_URL = 'http://jsonrpc:4000'
+VITE_PROXY_WS_SERVER_URL = 'ws://jsonrpc:4000'
+
 FRONTEND_BUILD_TARGET = 'final' # change to 'dev' to run in dev mode

--- a/docker/Dockerfile.webrequest
+++ b/docker/Dockerfile.webrequest
@@ -18,9 +18,9 @@ RUN mkdir -p $base && chown -R appuser:appuser $base
 
 USER appuser
 WORKDIR $base
-COPY --chown=appuser:appuser ../.env .
 COPY --chown=appuser:appuser $path $base/$path
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --cache-dir=/root/.cache/pip -r $path/requirements.txt
 WORKDIR $path
+COPY --chown=appuser:appuser ../.env .
 CMD ["python3", "server.py"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,33 +1,35 @@
-import { fileURLToPath, URL } from 'node:url'
-import svgLoader from 'vite-svg-loader'
+import { fileURLToPath, URL } from 'node:url';
+import svgLoader from 'vite-svg-loader';
 
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import vueJsx from '@vitejs/plugin-vue-jsx'
-import VueDevTools from 'vite-plugin-vue-devtools'
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import vueJsx from '@vitejs/plugin-vue-jsx';
+import VueDevTools from 'vite-plugin-vue-devtools';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/",
-  plugins: [
-    vue(),
-    svgLoader(),
-    vueJsx(),
-    VueDevTools(),
-  ],
+  base: '/',
+  plugins: [vue(), svgLoader(), vueJsx(), VueDevTools()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
   },
   preview: {
     port: 8080,
     strictPort: true,
-   },
-   server: {
+  },
+  server: {
     port: 8080,
     strictPort: true,
     host: true,
-    origin: "http://0.0.0.0:8080",
-   },
-})
+    origin: 'http://0.0.0.0:8080',
+    proxy: {
+      '/api': {
+        target: 'http://jsonrpc:4000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,35 +1,43 @@
 import { fileURLToPath, URL } from 'node:url';
 import svgLoader from 'vite-svg-loader';
 
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv, UserConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vueJsx from '@vitejs/plugin-vue-jsx';
 import VueDevTools from 'vite-plugin-vue-devtools';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: '/',
-  plugins: [vue(), svgLoader(), vueJsx(), VueDevTools()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-  preview: {
-    port: 8080,
-    strictPort: true,
-  },
-  server: {
-    port: 8080,
-    strictPort: true,
-    host: true,
-    origin: 'http://0.0.0.0:8080',
-    proxy: {
-      '/api': {
-        target: 'http://jsonrpc:4000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  const config: UserConfig = {
+    base: '/',
+    plugins: [vue(), svgLoader(), vueJsx(), VueDevTools()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
-  },
+    preview: {
+      port: 8080,
+      strictPort: true,
+    },
+    server: {
+      port: 8080,
+      strictPort: true,
+      host: true,
+      origin: 'http://0.0.0.0:8080',
+      proxy:
+        env.VITE_PROXY_ENABLED !== 'true'
+          ? undefined
+          : {
+              '/api': {
+                target: env.VITE_PROXY_JSON_RPC_SERVER_URL,
+                changeOrigin: true,
+                rewrite: (path) => path.replace(/^\/api/, ''),
+              },
+            },
+    },
+  };
+
+  return config;
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig(({ mode }) => {
                 changeOrigin: true,
               },
               '/socket.io': {
-                target: env.VITE_WS_SERVER_URL,
+                target: env.VITE_PROXY_WS_SERVER_URL,
                 ws: true,
                 rewriteWsOrigin: true,
               },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,7 +33,11 @@ export default defineConfig(({ mode }) => {
               '/api': {
                 target: env.VITE_PROXY_JSON_RPC_SERVER_URL,
                 changeOrigin: true,
-                rewrite: (path) => path.replace(/^\/api/, ''),
+              },
+              '/socket.io': {
+                target: env.VITE_WS_SERVER_URL,
+                ws: true,
+                rewriteWsOrigin: true,
               },
             },
     },

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,14 +1,16 @@
-import { fileURLToPath } from 'node:url'
-import { mergeConfig, defineConfig, configDefaults } from 'vitest/config'
-import viteConfig from './vite.config'
+import { fileURLToPath } from 'node:url';
+import { mergeConfig, defineConfig, configDefaults } from 'vitest/config';
+import viteConfig from './vite.config';
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
-    test: {
-      environment: 'jsdom',
-      exclude: [...configDefaults.exclude, 'test/e2e/**'],
-      root: fileURLToPath(new URL('./', import.meta.url))
-    }
-  })
-)
+export default defineConfig((env) =>
+  mergeConfig(
+    viteConfig(env),
+    defineConfig({
+      test: {
+        environment: 'jsdom',
+        exclude: [...configDefaults.exclude, 'test/e2e/**'],
+        root: fileURLToPath(new URL('./', import.meta.url)),
+      },
+    }),
+  ),
+);


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #476
Superseeds https://github.com/yeagerai/genlayer-simulator/pull/538

# What

Allows configuring proxy for the frontend to the backend with the following configuration 
```
VITE_PROXY_ENABLED = 'true'
VITE_JSON_RPC_SERVER_URL  = '/api'
VITE_WS_SERVER_URL='/' 
```

This envvars need to be present in the frontend build process. For example, by adding them in your `.env` file


# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to allow a new deployment architecture


# Testing done

<!-- Describe the tests you ran to verify your changes. -->

tested standard and new configuration. Both api and websockets worked correctly

# Decisions made

I have created this pr to superseed https://github.com/yeagerai/genlayer-simulator/pull/538 because I feel is faster. Nothing to do with how @rekpero worked, just a matter of process  

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

---

It's possible to automatically configure everything from `VITE_PROXY_ENABLED`, but that would require adding a configuration design pattern in the frontend, which 
- I feel it's not worth it given that it's not that hard of a configuration
- I don't feel confident implementing it

This could be a future improvement

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR


# Reviewing tips

Please test both configurations locally

# User facing release notes

Now you can proxy all requests trough the frontend: this allows you to only expose your frontend in your deployments
