### PR TITLE
fix(gh-actions): handle virtual environments in python pre-commit test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: backend-unit-pytest
         name: backend unit tests with pytest
-        entry: python3 -m pytest backend
+        entry: bash -c "[ -d ".venv" ] && source .venv/bin/activate && python3 -m pytest backend || pytest backend"
         language: system
         types: [python]
         pass_filenames: false


### PR DESCRIPTION
# What

Denis and Cristiam reported an issue while running the pytest pre-commit


# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- tested locally
- tested in this GH action

# Decisions made

We use `bash` to run multiple commands. We now require bash to be in the system 

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

Please test in your local machine with

` pre-commit run backend-unit-pytest --all-files`

# User facing release notes

Fixed `pre-commit` `pytest` configuration for developers
