### PR TITLE
ci: automatic releases will not be pre-release

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -27,7 +27,6 @@ jobs:
           echo $semver
           gh pr view $release_pr_number --json body --jq .body > body.txt
           cat body.txt
-          gh release create $semver --title $semver -F body.txt --prerelease
-        # TODO: remove prerelease flag after testing            ^^^^^^^^^^^^
+          gh release create $semver --title $semver -F body.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of https://github.com/yeagerai/genlayer-simulator/issues/334

# What

Makes the gh-action do a release instead of pre-release

# Why

Testing has already been done and working fine https://github.com/yeagerai/genlayer-simulator/releases/tag/0.4.0


# Testing done

<!-- Describe the tests you ran to verify your changes. -->

https://github.com/yeagerai/genlayer-simulator/releases/tag/0.4.0

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# User facing release notes

CI improvements: Automated GitHub releases when merging to main
