### PR TITLE
feat: expose webrequest get page in html format to intelligent contract sintax

### DIFF
--- a/backend/node/genvm/equivalence_principle.py
+++ b/backend/node/genvm/equivalence_principle.py
@@ -66,8 +66,8 @@ class EquivalencePrinciple:
             print("validation_response", validation_response)
             # if TRUE => nothing, FALSE => fuera todo y un state de disagree
 
-    async def get_webpage(self, url: str):
-        url_body = get_webpage_content(url)
+    async def get_webpage(self, url: str, format: str = "text"):
+        url_body = get_webpage_content(url, format)
         final_response = url_body["response"]
         return final_response
 
@@ -110,13 +110,15 @@ async def call_llm_with_principle(prompt, eq_principle, comparative=True):
     return final_result["output"]
 
 
-async def get_webpage_with_principle(url, eq_principle, comparative=True):
+async def get_webpage_with_principle(
+    url, eq_principle, comparative=True, format: str = "text"
+):
     final_result = {}
     async with EquivalencePrinciple(
         result=final_result,
         principle=eq_principle,
         comparative=comparative,
     ) as eq:
-        result = await eq.get_webpage(url)
+        result = await eq.get_webpage(url, format)
         eq.set(result)
     return final_result

--- a/backend/node/genvm/webpage_utils.py
+++ b/backend/node/genvm/webpage_utils.py
@@ -3,12 +3,12 @@ import requests
 import re
 
 
-def get_webpage_content(url: str) -> str:
+def get_webpage_content(url: str, format: str = "text") -> str:
 
     payload = {
         "jsonrpc": "2.0",
         "method": "get_webpage",
-        "params": [url],
+        "params": [url, format],
         "id": 2,
     }
 

--- a/examples/contracts/football_prediction_market.py
+++ b/examples/contracts/football_prediction_market.py
@@ -39,7 +39,7 @@ class PredictionMarket(IContract):
             principle="The score and the winner has to be exactly the same",
             comparative=True,
         ) as eq:
-            web_data = await eq.get_webpage(self.resolution_url)
+            web_data = await eq.get_webpage(self.resolution_url, "html")
             print(web_data)
 
             task = f"""In the following web page, find the winning team in a matchup between the following teams:

--- a/examples/contracts/football_prediction_market.py
+++ b/examples/contracts/football_prediction_market.py
@@ -39,7 +39,7 @@ class PredictionMarket(IContract):
             principle="The score and the winner has to be exactly the same",
             comparative=True,
         ) as eq:
-            web_data = await eq.get_webpage(self.resolution_url, "html")
+            web_data = await eq.get_webpage(self.resolution_url, "text")
             print(web_data)
 
             task = f"""In the following web page, find the winning team in a matchup between the following teams:

--- a/webrequest/server.py
+++ b/webrequest/server.py
@@ -43,20 +43,23 @@ def execution_time(start_time, end_time):
 
 
 @jsonrpc.method("get_webpage")
-def get_webpage(url: str) -> dict:
+def get_webpage(url: str, format: str = "text") -> dict:
     if not is_valid_url(url):
         return return_error("URL not in correct format")
     driver = get_webdriver()
     try:
         start_time = time()
-        webpage_text = get_text(driver, url)
+        if format == "text":
+            webpage_output = get_text(driver, url)
+        elif format == "html":
+            webpage_output = get_html(driver, url)
         end_time = time()
         execution_time(start_time, end_time)
     except Exception as e:
         if "ERR_NAME_NOT_RESOLVED" in str(e):
             return return_error("URL does not exist")
         return return_error(str(e))
-    return return_success(webpage_text)
+    return return_success(webpage_output)
 
 
 @jsonrpc.method("get_webpage_chunks")


### PR DESCRIPTION


<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #478 

# What

<!-- Describe the changes you made. -->

- The web page in HTML format method (get_html) from the webrequest module has been exposed in the equivalence principle functions by adding a new parameter called "format" in the EquivalencePrinciple.get_webpage method

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- This is needed for some use cases

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- I ran the integration tests for the prediction market example

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example, decisions on PR workflow -->

I added a new parameter to extend the current functionality instead of a new method that would require changes in the previous name, therefore breaking the existing examples.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Add format in the intelligent contract get_webpage and look at the result in the logs.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
Now, you can also get the content of a web page in HTML format; check the docs to learn how to pass an extra parameter to the get_webpage method and get the content in the format you prefer.