### PR TITLE
fix(protocol): get webpage should always be comparative

### DIFF
--- a/backend/node/genvm/equivalence_principle.py
+++ b/backend/node/genvm/equivalence_principle.py
@@ -110,12 +110,12 @@ async def call_llm_with_principle(prompt, eq_principle, comparative=True):
     return final_result["output"]
 
 
-async def get_webpage_with_principle(url, eq_principle, comparative=True):
+async def get_webpage_with_principle(url, eq_principle):
     final_result = {}
     async with EquivalencePrinciple(
         result=final_result,
         principle=eq_principle,
-        comparative=comparative,
+        comparative=True,
     ) as eq:
         result = await eq.get_webpage(url)
         eq.set(result)


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #437 

# What

<!-- Describe the changes you made. -->

- get_webpage_with_principle must always be comparative. For that reason, this parameter is getting removed from the method arguments.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- by definition, all get_webpage_with_principle calls should be comparative or the validator is not going to know how to agree.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- tested the prediction market contract with this shortcut function

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
Test this function in an intelligent contract

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->
The comparative flag has been removed from the get_webpage_with_principle method, ensuring it is always called with the comparative flag enabled.