### PR TITLE
ci(release): fix release GitHub action

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Install dependencies
-        run: npm install @semantic-release/github @semantic-release/release-notes-generator @semantic-release/commit-analyzer
+        run: npm install @semantic-release/github @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,8 @@ consensus/node_configs.json
 
 # don't include the nodes configuration
 consensus/nodes/nodes.json
+
+# npm
+node_modules/
+package-lock.json
+package.json

--- a/release.config.js
+++ b/release.config.js
@@ -1,8 +1,35 @@
 module.exports = {
     branches: ['main'],
-    plugins: [
-        '@semantic-release/commit-analyzer',
-        '@semantic-release/release-notes-generator',
-        '@semantic-release/github'
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "conventionalcommits",
+                "releaseRules": [
+                    { "type": "feat", "release": "minor" },
+                    { "type": "*", "release": "patch" },
+                ],
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits",
+                "presetConfig": {
+                    "header": "What's Changed",
+                    "types": [
+                        { "type": "feat", "section": "Features" },
+                        { "type": "fix", "section": "Bug Fixes" },
+                        { "type": "chore", "section": "Miscellaneous" },
+                        { "type": "docs", "section": "Miscellaneous" },
+                        { "type": "style", "section": "Miscellaneous" },
+                        { "type": "refactor", "section": "Miscellaneous" },
+                        { "type": "perf", "section": "Miscellaneous" },
+                        { "type": "test", "section": "Miscellaneous" }
+                    ]
+                },
+            }
+        ],
+        '@semantic-release/github',
     ]
 };

--- a/release.config.js
+++ b/release.config.js
@@ -16,7 +16,6 @@ module.exports = {
             {
                 "preset": "conventionalcommits",
                 "presetConfig": {
-                    "header": "What's Changed",
                     "types": [
                         { "type": "feat", "section": "Features" },
                         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
# What

Fixes current cronjob github action which was not working as expected


# Testing done
locally tested
```
$ npx semantic-release --dry-run

[3:02:22 PM] [semantic-release] › ℹ  Release note for version 0.5.1:
## 0.5.1 (2024-09-12)

### Miscellaneous

    * rpc endpoints (#481) (f4de409)








$ git commit --allow-empty -m "feat(a): test"
$ npx semantic-release --dry-run


[3:05:34 PM] [semantic-release] › ℹ  Release note for version 0.5.1:
## 0.5.1 (2024-09-12)

### Bug Fixes

    * a: test (8abc883)

### Miscellaneous

    * rpc endpoints (#481) (f4de409)







$ git commit --allow-empty -m "feat(b): test"
$ npx semantic-release --dry-run

[3:06:10 PM] [semantic-release] › ℹ  Release note for version 0.6.0:
## 0.6.0 (2024-09-12)

### Features

    * b: test (6694039)

### Bug Fixes

    * a: test (8abc883)

### Miscellaneous

    * rpc endpoints (#481) (f4de409)
```

# Decisions made

- Keep using `semantic-release`
- configured gitignore for npm in the root folder for testing locally

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)


# User facing release notes

Fixed a bug in the release GitHub action
