### PR TITLE
ci(release): release only from Monday to Thursday

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -1,7 +1,7 @@
 name: Create releases from main every day
 on:
   schedule:
-    - cron: "00 08 * * *" # Every day at 00:00 UTC
+    - cron: "00 08 * * 1-4" # 08:00 AM (UTC) from Monday to Thursday
 
 permissions:
   contents: read # for checkout


### PR DESCRIPTION
# Why

Releasing on weekends doesn't make sense ATM


# Decisions made

Don't release on friday

https://i.etsystatic.com/17819941/r/il/8217b8/2348534973/il_fullxfull.2348534973_g1km.jpg


# User facing release notes

Automatic releases will be done from Monday to Thursday