### PR TITLE
chore(postgres): upgrade Postgres from version 12 to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     restart: always
 
   postgres:
-    image: postgres:12.19-alpine
+    image: postgres:16-alpine
     ports:
       - "${DBPORT}:5432"
     environment:
@@ -76,7 +76,7 @@ services:
       retries: 3
 
     # If you want your db to persist in dev
-    #volumes:
+    # volumes:
     #  - "./data/postgres:/var/lib/postgresql/data"
 
   database-migration:


### PR DESCRIPTION
# Why

Postgres 12 is reaching EoL in November

# Testing done

docker compose up

# Decisions made

- chose version 16 since it's the latest, with the longest support

# Notes

!!! this will re-create the container, making user's lose all their data

I don't think there's 

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewer tips

If you had the volume set, I recomment you to destroy it. 
There are ways to save the content if you like https://hollo.me/devops/upgrade-postgresql-database-with-docker.html

# User facing release notes

Upgrade Postgres from version 12 to 16