### PR TITLE
ci(sonarcloud): fix organization name

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   frontend:
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: frontend
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -18,11 +20,10 @@ jobs:
           node-version: "21.x"
       - name: Copy examples to assets
         run: cp -r examples frontend/src/assets/examples
+        working-directory: .
 
       - run: npm ci
-        working-directory: frontend
       - run: npm run coverage
-        working-directory: frontend
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
@@ -30,4 +31,4 @@ jobs:
           verbose: true
           token: ${{ secrets.codecov_token }}
           fail_ci_if_error: true
-          directory: frontend/coverage
+          directory: coverage

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "21.x"
+          node-version: 20
       - name: Copy examples to assets
         run: cp -r examples frontend/src/assets/examples
         working-directory: .

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -31,4 +31,4 @@ jobs:
           verbose: true
           token: ${{ secrets.codecov_token }}
           fail_ci_if_error: true
-          directory: coverage
+          directory: frontend/coverage

--- a/.github/workflows/test-sonarqube.yml
+++ b/.github/workflows/test-sonarqube.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
   workflow_dispatch:
 
 jobs:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,4 @@
-sonar.organization=YeagerAI
+sonar.organization=yeagerai
 sonar.projectKey=yeagerai_genlayer-simulator
 
 # relative paths to source directories. More details and properties are described


### PR DESCRIPTION
# Why

jobs were failing https://github.com/yeagerai/genlayer-simulator/actions/runs/10853398354/job/30121579703

# Checks

- [ ] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Decisions made

Also run it on pull requests to see code quality diffs

# Reviewing tips

Taken from https://sonarcloud.io/project/information?id=yeagerai_genlayer-simulator

# User facing release notes

ci: Fixed SonarCloud organization key