### PR TITLE
changed renovatebot default branch to staging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,5 +19,6 @@
   "dependencyDashboard": true,
   "npm": {
     "minimumReleaseAge": "3 days"
-  }
+  },
+  "baseBranches": ["staging"]
 }


### PR DESCRIPTION
# What

changed renovatebot default branch to staging

# Why

Dependabot uses `default` branch, where it will create all PRs, which is `main`, but we use `staging` for merging all PRs