### PR TITLE
chore(docker): improve pip cache with buildkit

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -4,9 +4,9 @@ ARG path=/app
 WORKDIR $path
 
 ADD backend/protocol_rpc/requirements.txt backend/protocol_rpc/requirements.txt
-RUN pip install --upgrade pip \
-    && pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir -r backend/protocol_rpc/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --cache-dir=/root/.cache/pip torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --cache-dir=/root/.cache/pip -r backend/protocol_rpc/requirements.txt
 
 RUN groupadd -r backend-group \
     && useradd -r -g backend-group backend-user \
@@ -16,14 +16,15 @@ RUN groupadd -r backend-group \
 
 ENV PYTHONPATH "${PYTHONPATH}:/${path}"
 ENV FLASK_APP backend/protocol_rpc/server.py
-ENV TRANSFORMERS_CACHE /home/backend-user/.cache/huggingface
+ENV HUGGINGFACE_HUB_CACHE /home/backend-user/.cache/huggingface
 
 COPY ../.env .
 COPY backend $path/backend
 
 ###########START NEW IMAGE : DEBUGGER ###################
 FROM base AS debug
-RUN pip install --no-cache-dir debugpy watchdog
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --cache-dir=/root/.cache/pip debugpy watchdog
 USER backend-user
 CMD watchmedo auto-restart --no-restart-on-command-exit --recursive --pattern="*.py" --ignore-patterns="*.pyc;*__pycache__*" -- python -m debugpy --listen 0.0.0.0:${RPCDEBUGPORT} -m flask run -h 0.0.0.0 -p ${FLASK_SERVER_PORT}
 

--- a/docker/Dockerfile.database-migration
+++ b/docker/Dockerfile.database-migration
@@ -5,11 +5,11 @@ ARG path=/app
 WORKDIR $path
 
 ADD backend/protocol_rpc/requirements.txt backend/protocol_rpc/requirements.txt
-RUN pip install --upgrade pip \
-    && pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
-    && pip install --no-cache-dir -r backend/protocol_rpc/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --cache-dir=/root/.cache/pip torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --cache-dir=/root/.cache/pip -r backend/protocol_rpc/requirements.txt
 
-ENV TRANSFORMERS_CACHE /home/backend-user/.cache/huggingface
+ENV HUGGINGFACE_HUB_CACHE /home/backend-user/.cache/huggingface
 
 COPY ../.env .
 COPY backend $path/backend
@@ -19,7 +19,8 @@ FROM base AS migration
 ENV PYTHONPATH ""
 WORKDIR /app/backend/database_handler
 
-RUN pip install -r migration/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --cache-dir=/root/.cache/pip -r migration/requirements.txt
 
 ENTRYPOINT [ "alembic" ]
 CMD [ "upgrade", "head" ]

--- a/docker/Dockerfile.webrequest
+++ b/docker/Dockerfile.webrequest
@@ -20,6 +20,7 @@ USER appuser
 WORKDIR $base
 COPY --chown=appuser:appuser ../.env .
 COPY --chown=appuser:appuser $path $base/$path
-RUN pip install --no-cache-dir -r $path/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --cache-dir=/root/.cache/pip -r $path/requirements.txt
 WORKDIR $path
 CMD ["python3", "server.py"]


### PR DESCRIPTION
# What

uses buildkit cache mounts to try to reuse pip cache

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

by updating regularly the requirements.txt, we are invalidating the cache a lot

# Testing done

smoke tested locally

# Questions

The biggest package by far is `sentence-transformers`

Should we decouple the requirements.txt into many files? 
- ATM the requirements.txt also has testing packages
- separating the files would improve cache

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

learn about buildkit cache

# User facing release notes

You'll now get faster build times by leveraging the power of buildkit's cache
