### PR TITLE
ci: separate unit from load tests and remove pytest from pre-commit

### DIFF
--- a/.github/workflows/.pre-commit.yml
+++ b/.github/workflows/.pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: 3.11
           cache: pip
-      - run: pip install -r backend/protocol_rpc/requirements.txt
+      - run: pip install black
       # Set up Node.js
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -132,3 +132,11 @@ jobs:
 
       - name: Run Docker Compose
         run: docker compose -f tests/db-sqlalchemy/docker-compose.yml --project-directory . up tests --build --force-recreate --always-recreate-deps
+
+  load-test:
+    name: Load Tests
+    needs: triggers
+    if: ${{ needs.triggers.outputs.is_pull_request_opened == 'true' || needs.triggers.outputs.is_pull_request_review_approved == 'true' || needs.triggers.outputs.is_pull_request_labeled_with_run_tests == 'true' }}
+    uses: ./.github/workflows/load-test-oha.yml
+    with:
+      oha-version: "v1.4.5"

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -23,3 +23,13 @@ jobs:
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
+  backend-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: pip
+      - run: pip install -r backend/protocol_rpc/requirements.txt
+      - run: pytest tests/unit -vv

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -10,36 +10,16 @@ on:
     types:
       - submitted
       - edited
-
-concurrency:
-  group: unit-tests-${{ github.event.number }}
-  cancel-in-progress: true
+  push:
+    branches:
+      - main # so that test reports get uploaded to Codecov
 
 permissions:
   contents: read
 
 jobs:
-  triggers:
-    name: Get Triggers
-    runs-on: ubuntu-latest
-    outputs:
-      is_pull_request_opened: ${{ github.event_name == 'pull_request' && github.event.action == 'opened'}}
-      is_pull_request_review_approved: ${{ github.event_name == 'pull_request_review' && github.event.review.state == 'APPROVED'}}
-      is_pull_request_labeled_with_run_tests: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-tests')}}
-    steps:
-      - run: true
-  test:
+  frontend-unit-tests:
     name: Unit Tests
-    needs: triggers
-    if: ${{ needs.triggers.outputs.is_pull_request_opened == 'true' || needs.triggers.outputs.is_pull_request_review_approved == 'true' || needs.triggers.outputs.is_pull_request_labeled_with_run_tests == 'true' }}
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
-
-  load-test:
-    name: Load Tests
-    needs: triggers
-    if: ${{ needs.triggers.outputs.is_pull_request_opened == 'true' || needs.triggers.outputs.is_pull_request_review_approved == 'true' || needs.triggers.outputs.is_pull_request_labeled_with_run_tests == 'true' }}
-    uses: ./.github/workflows/load-test-oha.yml
-    with:
-      oha-version: "v1.4.5"

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -27,6 +27,7 @@ jobs:
   backend-unit-tests:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,6 @@ repos:
       - id: check-merge-conflict
       - id: no-commit-to-branch
         args: ["--branch", "main"]
-  - repo: local
-    hooks:
-      - id: backend-unit-pytest
-        name: backend unit tests with pytest
-        entry: bash -c 'if [ -d "venv" ]; then source venv/bin/activate; pytest tests/unit; else pytest tests/unit; fi'
-        language: system
-        types: [python]
-        pass_filenames: false
-        files: backend
-        always_run: false
   # Copied from https://black.readthedocs.io/en/stable/integrations/source_version_control.html
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.4.2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,4 @@ sonar.projectKey=yeagerai_genlayer-simulator
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=.
+sonar.exclusions=tests/**,


### PR DESCRIPTION
# What

- separate unit from load tests 
- remove pytest from pre-commit
- run unit tests in main (to fix [this codecov banners](https://github.com/yeagerai/genlayer-simulator/pull/525#issuecomment-2359184426))

# Why

To have better experience with CI

# Decisions made

I took the liberty to create this fix on my own since I felt that some parts of our CI were not working as expected, reducing my productivity

# Testing done

let's check the CI of this PR

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# User facing release notes

N/A