### PR TITLE
fix(jsonrpc): serialize result objects

### DIFF
--- a/tests/integration/contract_examples/test_llm_erc20.py
+++ b/tests/integration/contract_examples/test_llm_erc20.py
@@ -1,4 +1,5 @@
 # tests/e2e/test_storage.py
+import json
 from tests.common.request import (
     deploy_intelligent_contract,
     send_transaction,
@@ -40,7 +41,7 @@ def test_llm_erc20(setup_validators):
 
     # Deploy Contract
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
-        from_account_a, contract_code, f'{{"total_supply": "{TOKEN_TOTAL_SUPPLY}"}}'
+        from_account_a, contract_code, json.dumps({"total_supply": TOKEN_TOTAL_SUPPLY})
     )
 
     assert has_success_status(transaction_response_deploy)
@@ -51,7 +52,7 @@ def test_llm_erc20(setup_validators):
     contract_state_1 = call_contract_method(
         contract_address, from_account_a, "get_balances", []
     )
-    assert contract_state_1[from_account_a.address] == str(TOKEN_TOTAL_SUPPLY)
+    assert contract_state_1[from_account_a.address] == TOKEN_TOTAL_SUPPLY
 
     ########################################
     #### TRANSFER from User A to User B ####

--- a/tests/unit/test_endpoint_generator.py
+++ b/tests/unit/test_endpoint_generator.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from backend.protocol_rpc.endpoint_generator import _serialize
+
+
+def test_serialize():
+    assert _serialize(1) == 1
+    assert _serialize(1.1) == 1.1
+    assert _serialize("1") == "1"
+    assert _serialize(True) == True
+    assert _serialize(None) == None
+    assert _serialize(()) == []
+    assert _serialize({}) == {}
+    assert _serialize(dataclass()) == {}
+    assert _serialize("test") == "test"
+    assert _serialize((1, 2, ["test", False, ()])) == [1, 2, ["test", False, []]]

--- a/tests/unit/test_endpoint_generator.py
+++ b/tests/unit/test_endpoint_generator.py
@@ -13,3 +13,7 @@ def test_serialize():
     assert _serialize(dataclass()) == {}
     assert _serialize("test") == "test"
     assert _serialize((1, 2, ["test", False, ()])) == [1, 2, ["test", False, []]]
+    assert _serialize({"test": 1, "test2": {"test3": "test4"}}) == {
+        "test": 1,
+        "test2": {"test3": "test4"},
+    }


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #404

# What

- serializes results from the backend to be json compatible

# Why

- to handle more result types like tuples in IContracts

# Testing done

Tested manually this contract:

```py
from backend.node.genvm.icontract import IContract

class TTT(IContract):
    def __init__(self):
        pass

    def get_test(self):
        return 1, "test", 1, True, [1, (False)]
```

![image](https://github.com/user-attachments/assets/f324b8d2-5053-4550-8c56-cbdda1cbf7b1)


# Decisions made

- Created custom serialize function instead of importing another package to serialize objects
- I wanted to use the serialization of flask-jsonrpc, but I couldn't find its API

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

Test it out manually

# User facing release notes

Now you can use Python tuples in your Intelligent Contracts outputs
