### PR TITLE
feat: support both explicit and implicit vector ids in vector store

### DIFF
--- a/backend/node/genvm/std/vector_store.py
+++ b/backend/node/genvm/std/vector_store.py
@@ -17,21 +17,24 @@ class VectorStore:
         self.vector_data = {}  # Dictionary to store vectors
         self.metadata = {}  # Dictionary to store metadata
         self.model_name = model_name
-        self.next_id = 0
 
-    def add_text(self, text: str, metadata: Any):
+    def add_text(self, vector_id: int, text: str, metadata: Any):
         """
         Add a new text to the store with its metadata.
 
         Args:
             text (str): The text to be added.
             metadata (Any): The metadata.
+            vector_id (int, optional): The ID for the vector. If not provided, a new ID will be generated.
         """
+        if not vector_id:
+            vector_id = max(self.vector_data.keys(), default=0) + 1
+            print(f"generated id: {vector_id}")
+        elif vector_id in self.vector_data:
+            raise ValueError(f"Vector ID {vector_id} already exists")
 
         model = get_model(self.model_name)
         embedding = model.encode([text])[0]
-        vector_id = self.next_id
-        self.next_id += 1
 
         self.texts[vector_id] = text
         self.vector_data[vector_id] = embedding


### PR DESCRIPTION

Fixes #467 

# What

<!-- Describe the changes you made. -->

- Allow explicitly setting vector IDs in the vector store
- Still support implicit / auto-incremental fallback

# Why

- to add more flexibility to the developers

# Testing done

- tested the different cases of explicit / implicit ID

# Decisions made

- Kept both explicit and implicit ID for flexibility

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Try it out with the log_indexer example contract

# User facing release notes

- Vector store now also supports passing explicit vector ID when adding new vectors
