### PR TITLE
ci: fix tags not getting pushed to dockerhub

### DIFF
--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -44,7 +44,7 @@ jobs:
   database-migration:
     uses: ./.github/workflows/docker-build-and-push-image.yml
     with:
-      docker_build_context: backend/database_handler
+      docker_build_context: .
       dockerfile: docker/Dockerfile.database-migration
       dockerhub_repo: yeagerai/simulator-database-migration
       dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -33,3 +33,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release # Uses `release.config.js` for configuration
+      - name: Build images and push to DockerHub # Since GH Actions do not trigger other GH Actions (https://github.com/orgs/community/discussions/25702) we trigger it manually
+        uses: ./.github/workflows/docker-build-and-push-all.yml


### PR DESCRIPTION
# What

Fixes the problem that tags are not being pushed to docker hub

# Why

To get the images into dockerhub, I want to use them in other projects

# Testing done

None

# Decisions made

I could've used PATs as mentioned [here](https://github.com/orgs/community/discussions/25702), but 
- I couldn't create a PAT for this repo (not enabled by the yeagerai org probably)
- I think it's a "magic" solution. I like it better written explicitly

# Checks

- [ ] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips



# User facing release notes

N/A
