### PR TITLE
feat(deployment): add healthcheck for backend

### DIFF
--- a/backend/healthcheck.py
+++ b/backend/healthcheck.py
@@ -1,0 +1,34 @@
+"""
+File used to check the health of the backend API.
+We only check that the API is responding, and that the response is valid.
+"""
+
+import json
+import requests
+import argparse
+
+parser = argparse.ArgumentParser(description="Check the health of the backend API.")
+parser.add_argument(
+    "--port",
+    type=str,
+    nargs="?",
+    help="The port number for the API",
+)
+
+args = parser.parse_args()
+
+response = requests.post(
+    f"http://localhost:{args.port}/api",
+    data=json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "ping",
+            "params": [],
+            "id": 1,
+        }
+    ),
+    headers={"Content-Type": "application/json"},
+)
+assert response.status_code == 200
+print(response.json())
+assert response.json() == {"id": 1, "jsonrpc": "2.0", "result": "OK"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - ./examples:/app/src/assets/examples
       - ./frontend/src:/app/src
     depends_on:
-      - jsonrpc
+      jsonrpc:
+        condition: service_healthy
     expose:
       - "${FRONTEND_PORT}"
 
@@ -37,6 +38,12 @@ services:
         condition: service_completed_successfully
     expose:
       - "${RPCPORT}"
+    healthcheck:
+      test: python backend/healthcheck.py --port ${RPCPORT}
+      interval: 1s
+      timeout: 1s
+      retries: 15
+      start_period: 1s
 
   webrequest:
     build:


### PR DESCRIPTION
# What

Adds a healthcheck for the backend service

# Why

- In other applications I want to build depending on the simulator (feedbuzz, intelligent oracles) I need to depend on this service in order to be able to make calls to it. Healthchecks are the way to go for specifying dependencies between containers
- Healthchecks are a great idea in general

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- tested the new feature
- tested the bug fix

# Decisions made

- I've done it without using the `tests` module to not introduce module dependencies
- I've done it with a Python script since CURL nor WGET are available in the image

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

none

# User facing release notes

The backend container now has a healthcheck! You can use this to depend on it in your applications building on top of GenLayer's simulator
