### PR TITLE
feat: migrate to new calldata

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -355,8 +355,7 @@ class ConsensusAlgorithm:
                 transaction.to_address,  # new calls are done by the contract
                 pending_transaction.address,
                 {
-                    "function_name": pending_transaction.method_name,
-                    "function_args": json.dumps(pending_transaction.args),
+                    "calldata": pending_transaction.calldata,
                 },
                 value=0,  # we only handle EOA transfers at the moment, so no value gets transferred
                 type=TransactionType.RUN_CONTRACT.value,

--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -45,6 +45,15 @@ class TransactionsProcessor:
 
     @staticmethod
     def _transaction_data_to_str(data: dict) -> str:
+        """
+        NOTE: json doesn't support bytes object, so they need to be encoded somehow
+            Common approaches can be: array, hex string, base64 string
+            Array takes a lot of space (extra comma for each element)
+            Hex is double in size
+            Base64 is 1.33 in size
+            So base64 is chosen
+        """
+
         def data_encode(d):
             if isinstance(d, bytes):
                 return str(base64.b64encode(d), encoding="ascii")

--- a/backend/database_handler/types.py
+++ b/backend/database_handler/types.py
@@ -13,22 +13,6 @@ class ConsensusData:
         return {
             "final": self.final,
             "votes": self.votes,
-            "leader_receipt": {
-                "vote": self.leader_receipt.vote.value,
-                "execution_result": self.leader_receipt.execution_result.value,
-                "class_name": self.leader_receipt.class_name,
-                "method": self.leader_receipt.method,
-                "args": self.leader_receipt.args,
-                "gas_used": self.leader_receipt.gas_used,
-                "mode": self.leader_receipt.mode.value,
-                "contract_state": self.leader_receipt.contract_state,
-                "node_config": self.leader_receipt.node_config,
-                "eq_outputs": self.leader_receipt.eq_outputs,
-                "error": (
-                    str(self.leader_receipt.error)
-                    if self.leader_receipt.error
-                    else None
-                ),
-            },
+            "leader_receipt": self.leader_receipt.to_dict(),
             "validators": [receipt.to_dict() for receipt in self.validators],
         }

--- a/backend/node/create_nodes/create_nodes.py
+++ b/backend/node/create_nodes/create_nodes.py
@@ -50,6 +50,6 @@ def random_validator_config(
     providers_to_use = list(filter(filter_by_available, providers_to_use))
 
     if not providers_to_use:
-        raise Exception("No providers avaliable.")
+        raise Exception("No providers available.")
 
     return list(rng.choice(providers_to_use, amount))

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -178,7 +178,6 @@ class GenVM:
             encoded_pickled_object = None  # Default value in order to have something to return in case of error
             try:
                 calldata = calldata_decode(calldata_raw)
-                method_name = calldata["method"]
                 ctor_args = calldata["args"]
                 if not isinstance(ctor_args, list):
                     raise Exception(
@@ -186,7 +185,7 @@ class GenVM:
                     )
                 # Manual instantiation of the class is done to handle async __init__ methods
                 current_contract = contract_class.__new__(contract_class, *ctor_args)
-                ctor_method = getattr(contract_class, method_name)
+                ctor_method = getattr(contract_class, "__init__")
                 if inspect.iscoroutinefunction(ctor_method):
                     await ctor_method(current_contract, *ctor_args)
                 else:

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -28,6 +28,8 @@ from backend.protocol_rpc.message_handler.types import (
     EventScope,
 )
 
+from .calldata import decode as calldata_decode, encode as calldata_encode
+
 
 @contextmanager
 def safe_globals(override_globals: dict[str] = None):
@@ -96,15 +98,13 @@ class GenVM:
         self,
         class_name: str,
         encoded_object: str,
-        method_name: str,
-        args: list[str],
+        calldata: bytes,
         execution_result: ExecutionResultStatus,
         error: Exception,
     ) -> Receipt:
         return Receipt(
             class_name=class_name,
-            method=method_name,
-            args=args,
+            calldata=calldata,
             gas_used=self.contract_runner.gas_used,
             mode=self.contract_runner.mode,
             contract_state=encoded_object,
@@ -119,7 +119,7 @@ class GenVM:
         self,
         from_address: str,
         code_to_deploy: str,
-        constructor_args: dict,
+        calldata_raw: bytes,
         leader_receipt: Receipt | None,
     ):
         class_name = self._get_contract_class_name(code_to_deploy)
@@ -162,14 +162,20 @@ class GenVM:
 
             encoded_pickled_object = None  # Default value in order to have something to return in case of error
             try:
+                calldata = calldata_decode(calldata_raw)
+                method_name = calldata["method"]
+                ctor_args = calldata["args"]
+                if not isinstance(ctor_args, list):
+                    raise Exception(
+                        f"Invalid arguments, list expected, got {ctor_args}"
+                    )
                 # Manual instantiation of the class is done to handle async __init__ methods
-                current_contract = contract_class.__new__(
-                    contract_class, **constructor_args
-                )
-                if inspect.iscoroutinefunction(current_contract.__init__):
-                    await current_contract.__init__(**constructor_args)
+                current_contract = contract_class.__new__(contract_class, *ctor_args)
+                ctor_method = getattr(contract_class, method_name)
+                if inspect.iscoroutinefunction(ctor_method):
+                    await ctor_method(current_contract, *ctor_args)
                 else:
-                    current_contract.__init__(**constructor_args)
+                    ctor_method(current_contract, *ctor_args)
                 pickled_object = pickle.dumps(current_contract)
                 encoded_pickled_object = base64.b64encode(pickled_object).decode(
                     "utf-8"
@@ -212,7 +218,9 @@ class GenVM:
                         EventScope.GENVM,
                         "Deploying contract",
                         {
-                            "constructor_args": constructor_args,
+                            "calldata": str(
+                                base64.b64encode(calldata_raw), encoding="ascii"
+                            ),
                             "output": captured_stdout,
                         },
                     )
@@ -221,8 +229,7 @@ class GenVM:
         return self._generate_receipt(
             class_name,
             encoded_pickled_object,
-            "__init__",
-            [constructor_args],
+            calldata_raw,
             execution_result,
             error,
         )
@@ -230,8 +237,7 @@ class GenVM:
     async def run_contract(
         self,
         from_address: str,
-        function_name: str,
-        args: list,
+        calldata_raw: bytes,
         leader_receipt: Receipt | None,
     ) -> Receipt:
         self.contract_runner.from_address = from_address
@@ -271,13 +277,21 @@ class GenVM:
             decoded_pickled_object = base64.b64decode(contract_encoded_state)
             current_contract = pickle.loads(decoded_pickled_object)
 
-            function_to_run = getattr(current_contract, function_name, None)
-
+            method_name = "<error parsing>"
+            method_args = []
             try:
+                calldata = calldata_decode(calldata_raw)
+                method_name = calldata["method"]
+                method_args = calldata["args"]
+                if not isinstance(method_args, list):
+                    raise Exception(
+                        f"Invalid arguments, list expected, got {method_args}"
+                    )
+                function_to_run = getattr(current_contract, method_name)
                 if inspect.iscoroutinefunction(function_to_run):
-                    await function_to_run(*args)
+                    await function_to_run(*method_args)
                 else:
-                    function_to_run(*args)
+                    function_to_run(*method_args)
             except Exception as e:
                 trace = traceback.format_exc()
                 error = e
@@ -289,10 +303,11 @@ class GenVM:
                         "write_contract_failed",
                         EventType.ERROR,
                         EventScope.GENVM,
-                        "Error executing method " + function_name + ": " + str(error),
+                        "Error executing method " + method_name + ": " + str(error),
                         {
-                            "method_name": function_name,
-                            "method_args": args,
+                            "calldata": str(
+                                base64.b64encode(calldata_raw), encoding="ascii"
+                            ),
                             "error": str(error),
                             "traceback": f"\n{trace}",
                         },
@@ -316,10 +331,11 @@ class GenVM:
                         "write_contract",
                         EventType.INFO,
                         EventScope.GENVM,
-                        "Execute method: " + function_name,
+                        "Execute method: " + method_name,
                         {
-                            "method_name": function_name,
-                            "method_args": args,
+                            "calldata": str(
+                                base64.b64encode(calldata_raw), encoding="ascii"
+                            ),
                             "output": captured_stdout,
                         },
                     )
@@ -328,8 +344,7 @@ class GenVM:
         return self._generate_receipt(
             class_name,
             encoded_pickled_object,
-            function_name,
-            [args],
+            calldata_raw,
             execution_result,
             error,
         )
@@ -383,16 +398,17 @@ class GenVM:
 
     @staticmethod
     def get_abi_param_type(param_type: str) -> str:
+        # okay, this is unsolvable with current implementation...
         if param_type == "int":
-            return "uint256"
+            return "int"
         if param_type == "str":
             return "string"
         if param_type == "bool":
             return "bool"
         if param_type == "dict":
-            return "bytes"
+            return "any"
         if param_type == "list":
-            return "bytes"
+            return "any"
         if param_type == "None":
             return "None"
         return param_type
@@ -447,8 +463,7 @@ class GenVM:
         self,
         code: str,
         state: str,
-        method_name: str,
-        method_args: list,
+        calldata_raw: bytes,
         contract_snapshot_factory: Callable[[str], ContractSnapshot],
     ) -> Any:
         result = None
@@ -474,6 +489,10 @@ class GenVM:
             # Ensure the class and other necessary elements are in the global namespace if needed
             globals().update(local_namespace)
 
+            calldata = calldata_decode(calldata_raw)
+            method_name = calldata["method"]
+            method_args = calldata["args"]
+
             contract_state = pickle.loads(decoded_pickled_object)
             method_to_call = getattr(contract_state, method_name)
             result = method_to_call(*method_args)
@@ -492,8 +511,9 @@ class GenVM:
                         EventScope.GENVM,
                         "Call method: " + method_name,
                         {
-                            "method_name": method_name,
-                            "method_args": method_args,
+                            "calldata": str(
+                                base64.b64encode(calldata_raw), encoding="ascii"
+                            ),
                             "result": result,
                             "output": captured_stdout,
                         },
@@ -518,19 +538,19 @@ class ExternalContract:
         self.schedule_pending_transaction = schedule_pending_transaction
 
     def __getattr__(self, name):
-        def method(*args, **kwargs):
+        def method(*args):  # kwargs are not supported yet
             if re.match("get_", name):
                 return self.genvm.get_contract_data(
                     self.contract_snapshot.contract_code,
                     self.contract_snapshot.encoded_state,
-                    name,
-                    args,
+                    calldata_encode({"method": name, "args": args}),
                     self.contract_snapshot_factory,
                 )
             else:
                 self.schedule_pending_transaction(
                     PendingTransaction(
-                        address=self.address, method_name=name, args=args
+                        address=self.address,
+                        calldata=calldata_encode({"method": name, "args": args}),
                     )
                 )
 

--- a/backend/node/genvm/calldata.py
+++ b/backend/node/genvm/calldata.py
@@ -1,0 +1,157 @@
+from .types import Address
+from typing import Any
+
+BITS_IN_TYPE = 3
+
+TYPE_SPECIAL = 0
+TYPE_PINT = 1
+TYPE_NINT = 2
+TYPE_BYTES = 3
+TYPE_STR = 4
+TYPE_ARR = 5
+TYPE_MAP = 6
+
+SPECIAL_NULL = (0 << BITS_IN_TYPE) | TYPE_SPECIAL
+SPECIAL_FALSE = (1 << BITS_IN_TYPE) | TYPE_SPECIAL
+SPECIAL_TRUE = (2 << BITS_IN_TYPE) | TYPE_SPECIAL
+SPECIAL_ADDR = (3 << BITS_IN_TYPE) | TYPE_SPECIAL
+
+
+def encode(x: Any) -> bytes:
+    mem = bytearray()
+
+    def append_uleb128(i):
+        assert i >= 0
+        if i == 0:
+            mem.append(0)
+        while i > 0:
+            cur = i & 0x7F
+            i = i >> 7
+            if i > 0:
+                cur |= 0x80
+            mem.append(cur)
+
+    def impl(b):
+        if b is None:
+            mem.append(SPECIAL_NULL)
+        elif b is True:
+            mem.append(SPECIAL_TRUE)
+        elif b is False:
+            mem.append(SPECIAL_FALSE)
+        elif isinstance(b, int):
+            if b >= 0:
+                b = (b << 3) | TYPE_PINT
+                append_uleb128(b)
+            else:
+                b = -b - 1
+                b = (b << 3) | TYPE_NINT
+                append_uleb128(b)
+        elif isinstance(b, Address):
+            mem.append(SPECIAL_ADDR)
+            mem.extend(b.as_bytes)
+        elif isinstance(b, bytes):
+            lb = len(b)
+            lb = (lb << 3) | TYPE_BYTES
+            append_uleb128(lb)
+            mem.extend(b)
+        elif isinstance(b, str):
+            b = b.encode("utf-8")
+            lb = len(b)
+            lb = (lb << 3) | TYPE_STR
+            append_uleb128(lb)
+            mem.extend(b)
+        elif isinstance(b, (list, tuple)):
+            lb = len(b)
+            lb = (lb << 3) | TYPE_ARR
+            append_uleb128(lb)
+            for x in b:
+                impl(x)
+        elif isinstance(b, dict):
+            keys = list(b.keys())
+            keys.sort()
+            le = len(keys)
+            le = (le << 3) | TYPE_MAP
+            append_uleb128(le)
+            for k in keys:
+                if not isinstance(k, str):
+                    raise Exception(f"key is not string {type(k)}")
+                bts = k.encode("utf-8")
+                append_uleb128(len(bts))
+                mem.extend(bts)
+                impl(b[k])
+        else:
+            raise Exception(f"invalid type {type(b)}")
+
+    impl(x)
+    return bytes(mem)
+
+
+def decode(mem0) -> Any:  # type: ignore
+    mem: memoryview = memoryview(mem0)
+
+    def read_uleb128() -> int:
+        nonlocal mem
+        ret = 0
+        off = 0
+        while True:
+            m = mem[0]
+            ret = ret | ((m & 0x7F) << off)
+            off += 7
+            mem = mem[1:]
+            if (m & 0x80) == 0:
+                break
+        return ret
+
+    def impl() -> Any:
+        nonlocal mem
+        code = read_uleb128()
+        typ = code & 0x7
+        if typ == TYPE_SPECIAL:
+            if code == SPECIAL_NULL:
+                return None
+            if code == SPECIAL_FALSE:
+                return False
+            if code == SPECIAL_TRUE:
+                return True
+            if code == SPECIAL_ADDR:
+                ret_addr = mem[: Address.SIZE]
+                mem = mem[Address.SIZE :]
+                return Address(ret_addr)
+            raise Exception(f"Unknown special {bin(code)} {hex(code)}")
+        code = code >> 3
+        if typ == TYPE_PINT:
+            return code
+        elif typ == TYPE_NINT:
+            return -code - 1
+        elif typ == TYPE_BYTES:
+            ret_bytes = mem[:code]
+            mem = mem[code:]
+            return bytes(ret_bytes)
+        elif typ == TYPE_STR:
+            ret_str = mem[:code]
+            mem = mem[code:]
+            return str(ret_str, encoding="utf-8")
+        elif typ == TYPE_ARR:
+            ret_arr = []
+            for _i in range(code):
+                ret_arr.append(impl())
+            return ret_arr
+        elif typ == TYPE_MAP:
+            ret_dict: dict[str, Any] = {}
+            prev = None
+            for _i in range(code):
+                le = read_uleb128()
+                key = str(mem[:le], encoding="utf-8")
+                mem = mem[le:]
+                if prev is not None:
+                    assert prev < key
+                prev = key
+                assert key not in ret_dict
+                ret_dict[key] = impl()
+            return ret_dict
+        raise Exception(f"invalid type {typ}")
+
+    res = impl()
+    if len(mem) != 0:
+        raise Exception(f"unparsed end {bytes(mem[:5])!r}... (decoded {res})")
+    return res

--- a/backend/node/genvm/calldata.py
+++ b/backend/node/genvm/calldata.py
@@ -155,3 +155,44 @@ def decode(mem0) -> Any:  # type: ignore
     if len(mem) != 0:
         raise Exception(f"unparsed end {bytes(mem[:5])!r}... (decoded {res})")
     return res
+
+
+def to_str(d: Any) -> str:
+    buf: list[str] = []
+
+    def impl(d: Any) -> None:
+        if d is None:
+            buf.append("null")
+        elif d is True:
+            buf.append("true")
+        elif d is False:
+            buf.append("false")
+        elif isinstance(d, str):
+            buf.append(f"{d!r}")
+        elif isinstance(d, bytes):
+            buf.append("b#")
+            buf.append(d.hex())
+        elif isinstance(d, int):
+            buf.append(str(d))
+        elif isinstance(d, Address):
+            buf.append("addr#")
+            buf.append(d.as_bytes.hex())
+        elif isinstance(d, dict):
+            buf.append("{")
+            for k, v in d.items():
+                buf.append(f"{k!r}")
+                buf.append(":")
+                impl(v)
+                buf.append(",")
+            buf.append("}")
+        elif isinstance(d, list):
+            buf.append("[")
+            for v in d:
+                impl(v)
+                buf.append(",")
+            buf.append("]")
+        else:
+            raise Exception(f"can't encode {d} to calldata")
+
+    impl(d)
+    return "".join(buf)

--- a/backend/node/genvm/types.py
+++ b/backend/node/genvm/types.py
@@ -1,6 +1,40 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Iterable, Optional
+import base64
+
+
+class Address:
+    SIZE = 32
+    _as_bytes: bytes
+
+    def __init__(self, val: str | bytes | memoryview):
+        if isinstance(val, memoryview):
+            val = bytes(val)
+        if isinstance(val, str) or len(val) > Address.SIZE:
+            val = base64.b64decode(val)
+        if len(val) != Address.SIZE:
+            raise Exception("invalid address")
+        self._as_bytes = val
+
+    @property
+    def as_bytes(self) -> bytes:
+        return self._as_bytes
+
+    @property
+    def as_int(self) -> int:
+        return int.from_bytes(self._as_bytes, "little", signed=False)
+
+    def __hash__(self):
+        return hash(self._as_bytes)
+
+    def __eq__(self, r):
+        if not isinstance(r, Address):
+            return False
+        return self._as_bytes == r._as_bytes
+
+    def __repr__(self) -> str:
+        return "addr:[" + "".join(["{:02x}".format(x) for x in self._as_bytes]) + "]"
 
 
 class Vote(Enum):
@@ -21,15 +55,19 @@ class ExecutionResultStatus(Enum):
 @dataclass
 class PendingTransaction:
     address: str  # Address of the contract to call
-    method_name: str
-    args: list
+    calldata: bytes
+
+    def to_dict(self):
+        return {
+            "address": self.address,
+            "calldata": str(base64.b64encode(self.calldata), encoding="ascii"),
+        }
 
 
 @dataclass
 class Receipt:
     class_name: str
-    method: str
-    args: list[str]
+    calldata: bytes
     gas_used: int
     mode: ExecutionMode
     contract_state: str
@@ -45,8 +83,7 @@ class Receipt:
             "vote": self.vote.value,
             "execution_result": self.execution_result.value,
             "class_name": self.class_name,
-            "method": self.method,
-            "args": self.args,
+            "calldata": str(base64.b64encode(self.calldata), encoding="ascii"),
             "gas_used": self.gas_used,
             "mode": self.mode.value,
             "contract_state": self.contract_state,
@@ -54,7 +91,7 @@ class Receipt:
             "eq_outputs": self.eq_outputs,
             "error": str(self.error) if self.error else None,
             "pending_transactions": [
-                pending_transaction.__dict__
+                pending_transaction.to_dict()
                 for pending_transaction in self.pending_transactions
             ],
         }

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -400,18 +400,10 @@ def call(
         contract_snapshot_factory=partial(ContractSnapshot, session=session),
     )
 
-    method_args = decoded_data.function_args
-    if isinstance(method_args, str):
-        try:
-            method_args = json.loads(method_args)
-        except json.JSONDecodeError:
-            method_args = [method_args]
-
     return node.get_contract_data(
         code=contract_account["data"]["code"],
         state=contract_account["data"]["state"],
-        method_name=decoded_data.function_name,
-        method_args=method_args,
+        calldata=decoded_data.calldata,
     )
 
 
@@ -463,7 +455,7 @@ def send_raw_transaction(
         transaction_data = {
             "contract_address": new_contract_address,
             "contract_code": decoded_data.contract_code,
-            "constructor_args": decoded_data.constructor_args,
+            "calldata": decoded_data.calldata,
         }
         result["contract_address"] = new_contract_address
         to_address = None
@@ -476,10 +468,7 @@ def send_raw_transaction(
                 to_address, f"Invalid address to_address: {to_address}"
             )
         decoded_data = decode_method_call_data(decoded_transaction.data)
-        transaction_data = {
-            "function_name": decoded_data.function_name,
-            "function_args": decoded_data.function_args,
-        }
+        transaction_data = {"calldata": decoded_data.calldata}
         transaction_type = 2
         leader_only = decoded_data.leader_only
 

--- a/backend/protocol_rpc/transactions_parser.py
+++ b/backend/protocol_rpc/transactions_parser.py
@@ -1,7 +1,7 @@
 # rpc/transaction_utils.py
 
 import rlp
-from rlp.sedes import text
+from rlp.sedes import text, binary
 from rlp.exceptions import DeserializationError, SerializationError
 from eth_account import Account
 from eth_account._utils.legacy_transactions import Transaction, vrs_from
@@ -105,8 +105,7 @@ def decode_method_call_data(data: str) -> DecodedMethodCallData:
     leader_only = getattr(data_decoded, "leader_only", False)
 
     return DecodedMethodCallData(
-        function_name=data_decoded["function_name"],
-        function_args=data_decoded["function_args"],
+        calldata=data_decoded["calldata"],
         leader_only=leader_only,
     )
 
@@ -126,7 +125,7 @@ def decode_deployment_data(data: str) -> DecodedDeploymentData:
 
     return DecodedDeploymentData(
         contract_code=data_decoded["contract_code"],
-        constructor_args=data_decoded["constructor_args"],
+        calldata=data_decoded["calldata"],
         leader_only=leader_only,
     )
 
@@ -134,7 +133,7 @@ def decode_deployment_data(data: str) -> DecodedDeploymentData:
 class DeploymentContractTransactionPayload(rlp.Serializable):
     fields = [
         ("contract_code", text),
-        ("constructor_args", text),
+        ("calldata", binary),
         ("leader_only", boolean),
     ]
 
@@ -142,20 +141,18 @@ class DeploymentContractTransactionPayload(rlp.Serializable):
 class DeploymentContractTransactionPayloadDefault(rlp.Serializable):
     fields = [
         ("contract_code", text),
-        ("constructor_args", text),
+        ("calldata", binary),
     ]
 
 
 class MethodCallTransactionPayload(rlp.Serializable):
     fields = [
-        ("function_name", text),
-        ("function_args", text),
+        ("calldata", binary),
         ("leader_only", boolean),
     ]
 
 
 class MethodCallTransactionPayloadDefault(rlp.Serializable):
     fields = [
-        ("function_name", text),
-        ("function_args", text),
+        ("calldata", binary),
     ]

--- a/backend/protocol_rpc/types.py
+++ b/backend/protocol_rpc/types.py
@@ -28,7 +28,7 @@ class EndpointResult:
 class DecodedTransaction:
     from_address: str
     to_address: str
-    data: str
+    data: str  # hex encoded
     type: str
     nonce: int
     value: int
@@ -36,13 +36,12 @@ class DecodedTransaction:
 
 @dataclass
 class DecodedMethodCallData:
-    function_name: str
-    function_args: str
+    calldata: bytes
     leader_only: bool = False
 
 
 @dataclass
 class DecodedDeploymentData:
     contract_code: str
-    constructor_args: str
+    calldata: bytes
     leader_only: bool = False

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "sortablejs": "^1.15.3",
         "splitpanes": "^3.1.5",
         "tippy.js": "^6.3.7",
+        "typescript-parsec": "^0.3.4",
         "uuid": "^10.0.0",
         "v-plausible": "^1.2.0",
         "viem": "^2.16.5",
@@ -9343,6 +9344,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/typescript-parsec": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/typescript-parsec/-/typescript-parsec-0.3.4.tgz",
+      "integrity": "sha512-6RD4xOxp26BTZLopNbqT2iErqNhQZZWb5m5F07/UwGhldGvOAKOl41pZ3fxsFp04bNL+PbgMjNfb6IvJAC/uYQ==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.5.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "sortablejs": "^1.15.3",
     "splitpanes": "^3.1.5",
     "tippy.js": "^6.3.7",
+    "typescript-parsec": "^0.3.4",
     "uuid": "^10.0.0",
     "v-plausible": "^1.2.0",
     "viem": "^2.16.5",

--- a/frontend/src/calldata/encoder.ts
+++ b/frontend/src/calldata/encoder.ts
@@ -1,0 +1,161 @@
+import type { CalldataEncodable } from './types';
+import { Address } from './types';
+
+const BITS_IN_TYPE = 3;
+
+const TYPE_SPECIAL = 0;
+const TYPE_PINT = 1;
+const TYPE_NINT = 2;
+const TYPE_BYTES = 3;
+const TYPE_STR = 4;
+const TYPE_ARR = 5;
+const TYPE_MAP = 6;
+
+const SPECIAL_NULL = (0 << BITS_IN_TYPE) | TYPE_SPECIAL;
+const SPECIAL_FALSE = (1 << BITS_IN_TYPE) | TYPE_SPECIAL;
+const SPECIAL_TRUE = (2 << BITS_IN_TYPE) | TYPE_SPECIAL;
+const SPECIAL_ADDR = (3 << BITS_IN_TYPE) | TYPE_SPECIAL;
+
+function reportError(msg: string, data: CalldataEncodable): never {
+  throw new Error(`invalid calldata input '${data}'`);
+}
+
+function writeNum(to: number[], data: bigint) {
+  if (data === 0n) {
+    to.push(0);
+    return;
+  }
+  while (data > 0) {
+    let cur = Number(data & 0x7fn);
+    data >>= 7n;
+    if (data > 0) {
+      cur |= 0x80;
+    }
+    to.push(cur);
+  }
+}
+
+function encodeNumWithType(to: number[], data: bigint, type: number) {
+  const res = (data << BigInt(BITS_IN_TYPE)) | BigInt(type);
+  writeNum(to, res);
+}
+
+function encodeNum(to: number[], data: bigint) {
+  if (data >= 0n) {
+    encodeNumWithType(to, data, TYPE_PINT);
+  } else {
+    encodeNumWithType(to, -data - 1n, TYPE_NINT);
+  }
+}
+
+function compareString(l: Uint8Array, r: Uint8Array): number {
+  // FIXME it is incorrect for non ascii!
+  for (let index = 0; index < l.length && index < r.length; index++) {
+    const cur = l[index] - r[index];
+    if (cur !== 0) {
+      return cur;
+    }
+  }
+  return l.length - r.length;
+}
+
+function encodeMap(to: number[], arr: Iterable<[string, CalldataEncodable]>) {
+  const newEntries = Array.from(
+    arr,
+    ([k, v]): [Uint8Array, CalldataEncodable] => [
+      new TextEncoder().encode(k),
+      v,
+    ],
+  );
+  newEntries.sort(([k1, _v1], [k2, _v2]) => compareString(k1, k2));
+  for (let i = 1; i < newEntries.length; i++) {
+    if (compareString(newEntries[i - 1][0], newEntries[i][0]) === 0) {
+      throw new Error('duplicate key');
+    }
+  }
+
+  encodeNumWithType(to, BigInt(newEntries.length), TYPE_MAP);
+  for (const [k, v] of newEntries) {
+    writeNum(to, BigInt(k.length));
+    for (const c of k) {
+      to.push(c);
+    }
+    encodeImpl(to, v);
+  }
+}
+
+function encodeImpl(to: number[], data: CalldataEncodable) {
+  if (data === null || data === undefined) {
+    to.push(SPECIAL_NULL);
+    return;
+  }
+  if (data === true) {
+    to.push(SPECIAL_TRUE);
+    return;
+  }
+  if (data === false) {
+    to.push(SPECIAL_FALSE);
+    return;
+  }
+  switch (typeof data) {
+    case 'number': {
+      if (!Number.isInteger(data)) {
+        reportError('floats are not supported', data);
+      }
+      encodeNum(to, BigInt(data));
+      return;
+    }
+    case 'bigint': {
+      encodeNum(to, data);
+      return;
+    }
+    case 'string': {
+      const str = new TextEncoder().encode(data);
+      encodeNumWithType(to, BigInt(str.length), TYPE_STR);
+      for (const c of str) {
+        to.push(c);
+      }
+      return;
+    }
+    case 'object': {
+      if (data instanceof Uint8Array) {
+        encodeNumWithType(to, BigInt(data.length), TYPE_BYTES);
+        for (const c of data) {
+          to.push(c);
+        }
+      } else if (data instanceof Array) {
+        encodeNumWithType(to, BigInt(data.length), TYPE_ARR);
+        for (const c of data) {
+          encodeImpl(to, c);
+        }
+      } else if (data instanceof Map) {
+        encodeMap(to, data);
+      } else if (data instanceof Address) {
+        to.push(SPECIAL_ADDR);
+        for (const c of data.bytes) {
+          to.push(c);
+        }
+      } else if (Object.getPrototypeOf(data) === Object.prototype) {
+        encodeMap(
+          to,
+          Object.keys(data).map((k): [string, CalldataEncodable] => [
+            k,
+            data[k],
+          ]),
+        );
+      } else {
+        reportError('unknown object type', data);
+      }
+      return;
+    }
+    default:
+      reportError('unknown base type', data);
+  }
+}
+
+export function encode(data: CalldataEncodable): Uint8Array {
+  // FIXME: find a better growable type
+  const arr: number[] = [];
+  encodeImpl(arr, data);
+  return new Uint8Array(arr);
+}

--- a/frontend/src/calldata/index.ts
+++ b/frontend/src/calldata/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './encoder';
+export * from './parser';

--- a/frontend/src/calldata/parser.ts
+++ b/frontend/src/calldata/parser.ts
@@ -1,0 +1,211 @@
+import type { Token, Parser } from 'typescript-parsec';
+import {
+  buildLexer,
+  expectEOF,
+  expectSingleResult,
+  rule,
+} from 'typescript-parsec';
+import {
+  alt,
+  apply,
+  kleft,
+  kright,
+  list,
+  seq,
+  tok,
+  opt,
+} from 'typescript-parsec';
+
+import type { CalldataEncodable } from './types';
+import { Address } from './types';
+
+enum TokenKind {
+  Atom,
+  Number,
+  Str,
+  Bytes,
+  Addr,
+  LCpar,
+  RCpar,
+  LSpar,
+  RSpar,
+  Comma,
+  Colon,
+  Id,
+  Skip,
+}
+const lexer = buildLexer([
+  [false, /^\s+/g, TokenKind.Skip],
+  [false, /^\/\/[^\n]*/g, TokenKind.Skip],
+
+  [true, /^[-+]?(?:(?:0x[a-fA-F0-9]+)|(?:0o\d+)|\d+)/g, TokenKind.Number],
+  [true, /^(?:true|false|null)/g, TokenKind.Atom],
+  [true, /^addr#[a-fA-F0-9]+/g, TokenKind.Addr],
+  [true, /^b#[a-fA-F0-9]*/g, TokenKind.Bytes],
+  [true, /^\{/g, TokenKind.LCpar],
+  [true, /^\[/g, TokenKind.LSpar],
+  [true, /^\}/g, TokenKind.RCpar],
+  [true, /^\]/g, TokenKind.RSpar],
+  [true, /^,/g, TokenKind.Comma],
+  [true, /^:/g, TokenKind.Colon],
+  [true, /^(?!\d)\w\w*/g, TokenKind.Id],
+  [true, /^'(?:[^']|\\.)*'/g, TokenKind.Str],
+  [true, /^"(?:[^"]|\\.)*"/g, TokenKind.Str],
+]);
+
+const ATOMS = new Map([
+  ['null', null],
+  ['false', false],
+  ['true', true],
+]);
+
+function parseNumber(n: string, base: bigint): bigint {
+  const bn = Number(base);
+  const alphabet = '0123456789ABCDEF';
+  return Array.prototype.reduce.call(
+    n,
+    (acc: any, digit) => {
+      const pos = BigInt(alphabet.indexOf(digit.toUpperCase()));
+      if (pos >= bn || pos < 0) {
+        throw new Error(
+          `digit ${digit} (code point 0x${digit.codePointAt(0).toString(16)}) is out of range for base ${base}`,
+        );
+      }
+      return acc * base + pos;
+    },
+    0n,
+  ) as bigint;
+}
+
+function parseHex(text: string): Uint8Array {
+  if (text.length % 2 != 0) {
+    throw new Error('invalid hex length');
+  }
+  const res: number[] = [];
+  for (let i = 0; i < text.length; i += 2) {
+    res.push(parseInt(text.substring(i, i + 2), 16));
+  }
+  return new Uint8Array(res);
+}
+
+function applyNumber(n: Token<TokenKind.Number>) {
+  const txtSign = n.text;
+  let txtNoSign: string;
+  let sign = 1n;
+  if (txtSign.startsWith('-')) {
+    txtNoSign = txtSign.substring(1);
+    sign = -1n;
+  } else if (txtSign.startsWith('+')) {
+    txtNoSign = txtSign.substring(1);
+  } else {
+    txtNoSign = txtSign;
+  }
+
+  if (txtNoSign.startsWith('0x')) {
+    return parseNumber(txtNoSign.substring(2), 16n) * sign;
+  }
+  if (txtNoSign.startsWith('0o')) {
+    return parseNumber(txtNoSign.substring(2), 8n) * sign;
+  }
+  return parseNumber(txtNoSign, 10n) * sign;
+}
+
+function applyString(n: Token<TokenKind.Str>): string {
+  const txt = n.text.substring(1, n.text.length - 1);
+  return txt.replaceAll(/\\(?:u........|[^u])/g, (str) => {
+    if (str.startsWith('\\u')) {
+      const code = parseInt(str.substring(2), 16);
+      return String.fromCodePoint(code);
+    }
+    switch (str) {
+      case '\\\\':
+        return '\\';
+      case "\\'":
+        return "'";
+      case '\\"':
+        return '"';
+      case '\\n':
+        return '\n';
+      case '\\t':
+        return '\t';
+      case '\\r':
+        return '\r';
+      default:
+        throw new Error(`unsupported escape code ${str}`);
+    }
+  });
+}
+
+const TERM = rule<TokenKind, CalldataEncodable>();
+const ARR = rule<TokenKind, Array<CalldataEncodable>>();
+const MAP = rule<TokenKind, Map<string, CalldataEncodable>>();
+const EXPR = rule<TokenKind, CalldataEncodable>();
+
+const FETCH_STR = rule<TokenKind, string>();
+FETCH_STR.setPattern(apply(tok(TokenKind.Str), applyString));
+
+TERM.setPattern(
+  alt(
+    apply(tok(TokenKind.Atom), (v) => ATOMS.get(v.text) as CalldataEncodable),
+    FETCH_STR,
+    apply(tok(TokenKind.Number), applyNumber),
+    apply(tok(TokenKind.Bytes), (v) => parseHex(v.text.substring(2))),
+    apply(
+      tok(TokenKind.Addr),
+      (v) => new Address(parseHex(v.text.substring(5))),
+    ),
+  ),
+);
+
+ARR.setPattern(
+  parseArray(
+    tok(TokenKind.LSpar),
+    EXPR,
+    tok(TokenKind.Comma),
+    tok(TokenKind.RSpar),
+  ),
+);
+
+function parseArray<TKind, TRes, T1, T2, T3>(
+  left: Parser<TKind, T1>,
+  elem: Parser<TKind, TRes>,
+  sep: Parser<TKind, T2>,
+  right: Parser<TKind, T3>,
+): Parser<TKind, TRes[]> {
+  return kright(
+    left,
+    alt(
+      apply(right, () => []),
+      kleft(list(elem, sep), seq(opt(sep), right)),
+    ),
+  );
+}
+
+const ARR_ID = rule<TokenKind, string>();
+ARR_ID.setPattern(
+  alt(
+    FETCH_STR,
+    apply(tok(TokenKind.Id), (v) => v.text),
+  ),
+);
+
+MAP.setPattern(
+  apply(
+    parseArray(
+      tok(TokenKind.LCpar),
+      apply(
+        seq(ARR_ID, tok(TokenKind.Colon), EXPR),
+        (x): [string, CalldataEncodable] => [x[0], x[2]],
+      ),
+      tok(TokenKind.Comma),
+      tok(TokenKind.RCpar),
+    ),
+    (v) => new Map(v),
+  ),
+);
+
+EXPR.setPattern(alt(TERM, ARR, MAP));
+
+export function parse(s: string): CalldataEncodable {
+  return expectSingleResult(expectEOF(EXPR.parse(lexer.parse(s))));
+}

--- a/frontend/src/calldata/parser.ts
+++ b/frontend/src/calldata/parser.ts
@@ -67,8 +67,8 @@ const lexer = buildLexer([
   [true, /^,/g, TokenKind.Comma],
   [true, /^:/g, TokenKind.Colon],
   [true, /^(?!\d)\w\w*/g, TokenKind.Id],
-  [true, /^'(?:[^']|\\.)*'/g, TokenKind.Str],
-  [true, /^"(?:[^"]|\\.)*"/g, TokenKind.Str],
+  [true, /^'(?:[^'\\]|\\.)*'/g, TokenKind.Str],
+  [true, /^"(?:[^"\\]|\\.)*"/g, TokenKind.Str],
 ]);
 
 const ATOMS = new Map([

--- a/frontend/src/calldata/parser.ts
+++ b/frontend/src/calldata/parser.ts
@@ -136,9 +136,11 @@ function applyString(n: Token<TokenKind.Str>): string {
   });
 }
 
+/// unites all non-recursive non-terminals
 const TERM = rule<TokenKind, CalldataEncodable>();
 const ARR = rule<TokenKind, Array<CalldataEncodable>>();
 const MAP = rule<TokenKind, Map<string, CalldataEncodable>>();
+/// any valid calldata
 const EXPR = rule<TokenKind, CalldataEncodable>();
 
 const FETCH_STR = rule<TokenKind, string>();

--- a/frontend/src/calldata/parser.ts
+++ b/frontend/src/calldata/parser.ts
@@ -1,3 +1,21 @@
+/// This file introduces text format for calldata. It is quite similar to json, but has two more types: bytes and addresses
+/// Literals: null, true, false
+/// Numbers: 0, 0xff, 0o77, 89, -11 (integers of arbitrary size)
+/// Strings: "double quote", 'single quote', they support escapes: '\\', '\n', '\r', '\"', '\"'
+///   all strings must be valid (no unpaired surrogates, as js is utf16)
+/// Bytes: b#00ff (hex encoded, no quotes)
+/// Address: addr#3030303030303030303030303030303030303030303030303030303030303030 (32 bytes)
+/// Arrays: [], ['x'], ['trailing',]
+/// Maps: {}, { lit: 123 }, { "str": 456 }
+/// After encoding strings will be encoded as utf8, Map keys will be sorted
+
+/// More complex examples (left is js ;; right is calldata-str)
+/// new Uint8Array([0xff]) ;; b#ff
+/// 1n ;; 1
+/// -1n ;; -1
+/// "123" ;; "123"
+/// { "a": 123 } ;; { "a": 123 }
+
 import type { Token, Parser } from 'typescript-parsec';
 import {
   buildLexer,

--- a/frontend/src/calldata/types.ts
+++ b/frontend/src/calldata/types.ts
@@ -16,11 +16,11 @@ export type CalldataEncodable =
   | number
   | bigint
   | string
-  | Uint8Array
+  | Uint8Array /// bytes
   | Address
   | Array<CalldataEncodable>
   | Map<string, CalldataEncodable>
-  | { [key: string]: CalldataEncodable };
+  | { [key: string]: CalldataEncodable }; /// also a "map"
 
 export type MethodDescription = {
   method: string;

--- a/frontend/src/calldata/types.ts
+++ b/frontend/src/calldata/types.ts
@@ -2,7 +2,7 @@ export class Address {
   bytes: Uint8Array;
 
   constructor(addr: Uint8Array) {
-    if (addr.length != 32) {
+    if (addr.length != 20) {
       throw new Error(`invalid address length ${addr}`);
     }
     this.bytes = addr;

--- a/frontend/src/calldata/types.ts
+++ b/frontend/src/calldata/types.ts
@@ -1,0 +1,33 @@
+export class Address {
+  bytes: Uint8Array;
+
+  constructor(addr: Uint8Array) {
+    if (addr.length != 32) {
+      throw new Error(`invalid address length ${addr}`);
+    }
+    this.bytes = addr;
+  }
+}
+
+export type CalldataEncodable =
+  | null
+  | boolean
+  | Address
+  | number
+  | bigint
+  | string
+  | Uint8Array
+  | Address
+  | Array<CalldataEncodable>
+  | Map<string, CalldataEncodable>
+  | { [key: string]: CalldataEncodable };
+
+export type MethodDescription = {
+  method: string;
+  args: Array<CalldataEncodable>;
+};
+
+export type TransactionData = {
+  method: string;
+  args: CalldataEncodable[];
+};

--- a/frontend/src/clients/web3.ts
+++ b/frontend/src/clients/web3.ts
@@ -9,6 +9,13 @@ import type {
 } from 'viem';
 import type { Address } from '@/types';
 
+export type TransactionDataElement =
+  | string
+  | number
+  | bigint
+  | boolean
+  | Uint8Array;
+
 export class Web3Client {
   privateKeyToAccount(privateKey: Address) {
     return _privateKeyToAccount(privateKey);
@@ -18,7 +25,7 @@ export class Web3Client {
     return _generatePrivateKey();
   }
 
-  encodeTransactionData(params: any[]) {
+  encodeTransactionData(params: TransactionDataElement[]) {
     return toRlp(params.map((param) => toHex(param)));
   }
 
@@ -34,7 +41,7 @@ export class Web3Client {
     nonce,
   }: {
     privateKey: Address;
-    data: Array<unknown>;
+    data: TransactionDataElement[];
     to?: Address;
     value?: bigint;
     nonce: number;

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -19,12 +19,14 @@ const props = defineProps<{
 }>();
 
 const isExpanded = ref(false);
-const inputs = ref<{ [k: string]: any }>({});
+const inputs = ref<{ [k: string]: string }>({});
 const responseMessage = ref('');
 
 const missingParams = computed(() => {
   return props.method.inputs.some(
-    (input: any) => inputs.value[input.name] === '',
+    (input: any) =>
+      typeof inputs.value[input.name] === 'string' &&
+      inputs.value[input.name].trim() === '',
   );
 });
 
@@ -55,7 +57,7 @@ const handleCallReadMethod = async () => {
 const handleCallWriteMethod = async () => {
   await callWriteMethod({
     method: props.method.name,
-    params: Object.values(inputs.value),
+    args: Object.values(inputs.value),
     leaderOnly: props.leaderOnly,
   });
 
@@ -79,13 +81,13 @@ const resetInputs = () => {
     switch (input.type) {
       case 'uint256':
       case 'float':
-        defaultValue = 0;
+        defaultValue = '0';
         break;
       case 'bool':
-        defaultValue = false;
+        defaultValue = 'false';
         break;
       case 'string':
-        defaultValue = '';
+        defaultValue = '""';
         break;
       default:
         defaultValue = '';

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -6,6 +6,7 @@ import { useInputMap } from '@/hooks';
 import { notify } from '@kyvg/vue3-notification';
 import { ChevronDownIcon } from '@heroicons/vue/16/solid';
 import { useEventTracking, useContractQueries } from '@/hooks';
+import * as calldata from '@/calldata';
 
 const { callWriteMethod, callReadMethod, contract } = useContractQueries();
 const { trackEvent } = useEventTracking();
@@ -30,14 +31,20 @@ const missingParams = computed(() => {
   );
 });
 
+const getArgs = () => {
+  return Object.keys(inputs.value).map((key) => {
+    if (props.method.inputs.find((v) => v.name == key)?.type === 'string') {
+      return inputs.value[key];
+    }
+    return calldata.parse(inputs.value[key]);
+  });
+};
+
 const handleCallReadMethod = async () => {
   responseMessage.value = '';
 
   try {
-    const result = await callReadMethod(
-      props.method.name,
-      Object.values(inputs.value),
-    );
+    const result = await callReadMethod(props.method.name, getArgs());
 
     responseMessage.value = JSON.stringify(result);
 
@@ -57,7 +64,7 @@ const handleCallReadMethod = async () => {
 const handleCallWriteMethod = async () => {
   await callWriteMethod({
     method: props.method.name,
-    args: Object.values(inputs.value),
+    args: getArgs(),
     leaderOnly: props.leaderOnly,
   });
 

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -94,7 +94,7 @@ const resetInputs = () => {
         defaultValue = 'false';
         break;
       case 'string':
-        defaultValue = '""';
+        defaultValue = '';
         break;
       default:
         defaultValue = '';

--- a/frontend/src/components/Simulator/ContractReadMethods.vue
+++ b/frontend/src/components/Simulator/ContractReadMethods.vue
@@ -15,9 +15,9 @@ const { contractAbiQuery } = useContractQueries();
 const { data, isPending, isError, error, isRefetching } = contractAbiQuery;
 
 const readMethods = computed(() => {
-  return data.value.abi
-    .filter((method: ContractMethod) => method.type !== 'constructor')
-    .filter((method: ContractMethod) => method.name.startsWith('get_'));
+  return (data.value.abi as ContractMethod[])
+    .filter((method) => method.type !== 'constructor')
+    .filter((method) => method.name.startsWith('get_'));
 });
 </script>
 

--- a/frontend/src/components/Simulator/TransactionItem.vue
+++ b/frontend/src/components/Simulator/TransactionItem.vue
@@ -16,6 +16,7 @@ const nodeStore = useNodeStore();
 const props = defineProps<{
   transaction: TransactionItem;
 }>();
+console.log('🚀 ~ transaction:', props.transaction);
 
 const isDetailsModalOpen = ref(false);
 
@@ -55,7 +56,7 @@ const shortHash = computed(() => {
     <div class="grow truncate text-left text-[11px] font-medium">
       {{
         transaction.type === 'method'
-          ? transaction.data.data?.function_name
+          ? transaction.decodedData?.functionName
           : 'Deploy'
       }}
     </div>

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -75,7 +75,6 @@ export function useContractQueries() {
   const isDeploying = ref(false);
 
   async function deployContract(
-    method: string,
     args: calldata.CalldataEncodable[],
     leaderOnly: boolean,
   ) {
@@ -87,7 +86,7 @@ export function useContractQueries() {
       }
       const data = [
         contract.value?.content ?? '',
-        calldata.encode({ method, args }),
+        calldata.encode({ args }),
         leaderOnly,
       ];
 
@@ -158,11 +157,12 @@ export function useContractQueries() {
     return result;
   }
 
-  async function callReadMethod(method: string, args: string[]) {
+  async function callReadMethod(
+    method: string,
+    args: calldata.CalldataEncodable[],
+  ) {
     try {
-      const data = [
-        calldata.encode({ method, args: args.map(calldata.parse) }),
-      ];
+      const data = [calldata.encode({ method, args })];
       const encodedData = wallet.encodeTransactionData(data);
 
       const result = await rpcClient.getContractState({
@@ -184,17 +184,14 @@ export function useContractQueries() {
     leaderOnly,
   }: {
     method: string;
-    args: string[];
+    args: calldata.CalldataEncodable[];
     leaderOnly: boolean;
   }) {
     try {
       if (!accountsStore.currentPrivateKey) {
         throw new Error('Error Deploying the contract');
       }
-      const data = [
-        calldata.encode({ method, args: args.map(calldata.parse) }),
-        leaderOnly,
-      ];
+      const data = [calldata.encode({ method, args }), leaderOnly];
       const to = (address.value as Address) || null;
 
       const nonce = await accountsStore.getCurrentNonce();

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -10,6 +10,7 @@ import { useDebounceFn } from '@vueuse/core';
 import { notify } from '@kyvg/vue3-notification';
 import { useMockContractData } from './useMockContractData';
 import { useEventTracking, useRpcClient, useWallet } from '@/hooks';
+import * as calldata from '@/calldata';
 
 const schema = ref<any>();
 
@@ -74,7 +75,8 @@ export function useContractQueries() {
   const isDeploying = ref(false);
 
   async function deployContract(
-    constructorParams: { [k: string]: string },
+    method: string,
+    args: calldata.CalldataEncodable[],
     leaderOnly: boolean,
   ) {
     isDeploying.value = true;
@@ -83,10 +85,9 @@ export function useContractQueries() {
       if (!contract.value || !accountsStore.currentPrivateKey) {
         throw new Error('Error Deploying the contract');
       }
-      const constructorParamsAsString = JSON.stringify(constructorParams);
       const data = [
         contract.value?.content ?? '',
-        constructorParamsAsString,
+        calldata.encode({ method, args }),
         leaderOnly,
       ];
 
@@ -157,10 +158,11 @@ export function useContractQueries() {
     return result;
   }
 
-  async function callReadMethod(method: string, methodArguments: string[]) {
+  async function callReadMethod(method: string, args: string[]) {
     try {
-      const methodParamsAsString = JSON.stringify(methodArguments);
-      const data = [method, methodParamsAsString];
+      const data = [
+        calldata.encode({ method, args: args.map(calldata.parse) }),
+      ];
       const encodedData = wallet.encodeTransactionData(data);
 
       const result = await rpcClient.getContractState({
@@ -178,19 +180,21 @@ export function useContractQueries() {
 
   async function callWriteMethod({
     method,
-    params,
+    args,
     leaderOnly,
   }: {
     method: string;
-    params: any[];
+    args: string[];
     leaderOnly: boolean;
   }) {
     try {
       if (!accountsStore.currentPrivateKey) {
         throw new Error('Error Deploying the contract');
       }
-      const methodParamsAsString = JSON.stringify(params);
-      const data = [method, methodParamsAsString, leaderOnly];
+      const data = [
+        calldata.encode({ method, args: args.map(calldata.parse) }),
+        leaderOnly,
+      ];
       const to = (address.value as Address) || null;
 
       const nonce = await accountsStore.getCurrentNonce();

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -211,6 +211,10 @@ export function useContractQueries() {
         type: 'method',
         status: 'PENDING',
         data: {},
+        decodedData: {
+          functionName: method,
+          args,
+        },
       });
       return true;
     } catch (error) {

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -32,6 +32,10 @@ export interface TransactionItem {
   contractAddress: string;
   localContractId: string;
   data?: any;
+  decodedData?: {
+    functionName: string;
+    args: any[];
+  };
 }
 
 export type UIMode = 'light' | 'dark';

--- a/frontend/test/unit/calldata/parse.test.ts
+++ b/frontend/test/unit/calldata/parse.test.ts
@@ -36,7 +36,7 @@ describe('calldata parsing tests', () => {
             str2: "abc",
             num: 0xf,
             bytes: b#dead,
-            addr: addr#0000000000000000000000000000000000000000000000000000000000000000,
+            addr: addr#0000000000000000000000000000000000000000,
             arr: [-2, -0o7, -0xff00, -0]
         }`;
     const asLiteral = {
@@ -47,7 +47,7 @@ describe('calldata parsing tests', () => {
       str2: 'abc',
       num: 0xf,
       bytes: new Uint8Array([0xde, 0xad]),
-      addr: new calldata.Address(new Uint8Array(new Array(32).map(() => 0))),
+      addr: new calldata.Address(new Uint8Array(new Array(20).map(() => 0))),
       arr: [-2, -0o7, -0xff00, -0],
     };
 

--- a/frontend/test/unit/calldata/parse.test.ts
+++ b/frontend/test/unit/calldata/parse.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+
+import * as calldata from '@/calldata';
+
+describe('calldata parsing tests', () => {
+  it('string escapes', () => {
+    expect(calldata.parse('"\\n"')).toEqual('\n');
+    expect(calldata.parse('"\\r"')).toEqual('\r');
+    expect(calldata.parse('"\\t"')).toEqual('\t');
+    expect(calldata.parse('"\\u00029e3d"')).toEqual('𩸽');
+  });
+  it('numbers', () => {
+    expect(calldata.parse('0')).toEqual(0n);
+    expect(calldata.parse('0xff')).toEqual(0xffn);
+    expect(calldata.parse('0o77')).toEqual(0o77n);
+  });
+
+  it('numbers + sign', () => {
+    expect(calldata.parse('+0')).toEqual(0n);
+    expect(calldata.parse('+0xff')).toEqual(0xffn);
+    expect(calldata.parse('+0o77')).toEqual(0o77n);
+  });
+
+  it('numbers - sign', () => {
+    expect(calldata.parse('-0')).toEqual(-0n);
+    expect(calldata.parse('-0xff')).toEqual(-0xffn);
+    expect(calldata.parse('-0o77')).toEqual(-0o77n);
+  });
+
+  it('all types', () => {
+    const asStr = `{
+            'true': true,
+            'false': false,
+            'null': null,
+            str: '123',
+            str2: "abc",
+            num: 0xf,
+            bytes: b#dead,
+            addr: addr#0000000000000000000000000000000000000000000000000000000000000000,
+            arr: [-2, -0o7, -0xff00, -0]
+        }`;
+    const asLiteral = {
+      true: true,
+      false: false,
+      null: null,
+      str: '123',
+      str2: 'abc',
+      num: 0xf,
+      bytes: new Uint8Array([0xde, 0xad]),
+      addr: new calldata.Address(new Uint8Array(new Array(32).map(() => 0))),
+      arr: [-2, -0o7, -0xff00, -0],
+    };
+
+    expect(calldata.encode(calldata.parse(asStr))).toEqual(
+      calldata.encode(asLiteral),
+    );
+  });
+
+  it('trailing comma', () => {
+    const asStr = `
+        {
+            a: {},
+            b: {x: 2,},
+            c: [],
+            d: [1,],
+        }`;
+    const asLit = {
+      a: {},
+      b: { x: 2 },
+      c: [],
+      d: [1],
+    };
+    expect(calldata.encode(calldata.parse(asStr))).toEqual(
+      calldata.encode(asLit),
+    );
+  });
+});

--- a/frontend/test/unit/calldata/parse.test.ts
+++ b/frontend/test/unit/calldata/parse.test.ts
@@ -74,4 +74,18 @@ describe('calldata parsing tests', () => {
       calldata.encode(asLit),
     );
   });
+
+  it('string escapes', () => {
+    expect(calldata.parse('"\\\\"')).toEqual('\\');
+    expect(calldata.parse('"\\n"')).toEqual('\n');
+
+    expect(() => calldata.parse('"\\a"')).toThrow();
+  });
+
+  it('errors', () => {
+    expect(() => calldata.parse('b#1')).toThrow();
+    expect(() => calldata.parse('0xz')).toThrow();
+    expect(() => calldata.parse('0o8')).toThrow();
+    expect(() => calldata.parse('addr#1234')).toThrow();
+  });
 });

--- a/tests/common/request.py
+++ b/tests/common/request.py
@@ -98,7 +98,10 @@ def deploy_intelligent_contract(
     account: Account, contract_code: str, method_args: list
 ) -> tuple[str, dict]:
     nonce = get_transaction_count(account.address)
-    deploy_data = [contract_code, calldata.encode({"method": "__init__", "args": method_args}),]
+    deploy_data = [
+        contract_code,
+        calldata.encode({"method": "__init__", "args": method_args}),
+    ]
     signed_transaction = sign_transaction(account, deploy_data, nonce=nonce)
     result = send_raw_transaction(signed_transaction)
     contract_address = result["data"]["contract_address"]

--- a/tests/common/request.py
+++ b/tests/common/request.py
@@ -8,6 +8,8 @@ from eth_account import Account
 
 from tests.common.transactions import sign_transaction, encode_transaction_data
 
+import backend.node.genvm.calldata as calldata
+
 load_dotenv()
 
 
@@ -57,8 +59,9 @@ def call_contract_method(
     method_name: str,
     method_args: list,
 ):
-    params_as_string = json.dumps(method_args)
-    encoded_data = encode_transaction_data([method_name, params_as_string])
+    encoded_data = encode_transaction_data(
+        [calldata.encode({"method": method_name, "args": method_args})]
+    )
     method_response = post_request_localhost(
         payload(
             "eth_call",
@@ -82,7 +85,7 @@ def send_transaction(
     call_data = (
         None
         if method_name is None and method_args is None
-        else [method_name, json.dumps(method_args)]
+        else [calldata.encode({"method": method_name, "args": method_args})]
     )
     nonce = get_transaction_count(account.address)
     signed_transaction = sign_transaction(
@@ -92,10 +95,10 @@ def send_transaction(
 
 
 def deploy_intelligent_contract(
-    account: Account, contract_code: str, constructor_params: str
+    account: Account, contract_code: str, method_args: list
 ) -> tuple[str, dict]:
     nonce = get_transaction_count(account.address)
-    deploy_data = [contract_code, constructor_params]
+    deploy_data = [contract_code, calldata.encode({"method": "__init__", "args": method_args}),]
     signed_transaction = sign_transaction(account, deploy_data, nonce=nonce)
     result = send_raw_transaction(signed_transaction)
     contract_address = result["data"]["contract_address"]

--- a/tests/common/transactions.py
+++ b/tests/common/transactions.py
@@ -5,8 +5,7 @@ from eth_account._utils.legacy_transactions import Transaction
 
 
 def encode_transaction_data(data: list) -> str:
-    params_bytes = [bytes(param, "utf-8") for param in data]
-    serialized_data = rlp.encode(params_bytes)
+    serialized_data = rlp.encode(data)
     return to_hex(serialized_data)
 
 

--- a/tests/integration/contract_examples/mocks/call_contract_function.py
+++ b/tests/integration/contract_examples/mocks/call_contract_function.py
@@ -2,14 +2,13 @@ call_contract_function_response = {
     "consensus_data": {
         "final": bool,
         "leader_receipt": {
-            "args": list,
             "class_name": str,
+            "calldata": str,
             "contract_state": str,
             "eq_outputs": {"leader": dict},
             "error": str | None,
             "execution_result": str,
             "gas_used": int,
-            "method": str,
             "mode": str,
             "node_config": {
                 "address": str,
@@ -27,8 +26,7 @@ call_contract_function_response = {
     },
     "created_at": str,
     "data": {
-        "function_args": str,  # TODO: can we make this a list?
-        "function_name": str,
+        "calldata": str,
     },
     "from_address": str,
     "hash": str,

--- a/tests/integration/contract_examples/mocks/llm_erc20_get_contract_schema_for_code.py
+++ b/tests/integration/contract_examples/mocks/llm_erc20_get_contract_schema_for_code.py
@@ -4,13 +4,13 @@ llm_erc20_contract_schema = {
     "result": {
         "abi": [
             {
-                "inputs": [{"name": "total_supply", "type": "uint256"}],
+                "inputs": [{"name": "total_supply", "type": "int"}],
                 "type": "constructor",
             },
             {
                 "inputs": [{"name": "address", "type": "string"}],
                 "name": "get_balance_of",
-                "outputs": [{"name": "", "type": "uint256"}],
+                "outputs": [{"name": "", "type": "int"}],
                 "type": "function",
             },
             {
@@ -21,7 +21,7 @@ llm_erc20_contract_schema = {
             },
             {
                 "inputs": [
-                    {"name": "amount", "type": "uint256"},
+                    {"name": "amount", "type": "int"},
                     {"name": "to_address", "type": "string"},
                 ],
                 "name": "transfer",

--- a/tests/integration/contract_examples/mocks/log_indexer_get_contract_schema_for_code.py
+++ b/tests/integration/contract_examples/mocks/log_indexer_get_contract_schema_for_code.py
@@ -7,7 +7,7 @@ log_indexer_contract_schema = {
             {
                 "inputs": [
                     {"name": "log", "type": "string"},
-                    {"name": "log_id", "type": "uint256"},
+                    {"name": "log_id", "type": "int"},
                 ],
                 "name": "add_log",
                 "outputs": [],
@@ -16,26 +16,26 @@ log_indexer_contract_schema = {
             {
                 "inputs": [{"name": "text", "type": "string"}],
                 "name": "get_closest_vector",
-                "outputs": [{"name": "", "type": "bytes"}],
+                "outputs": [{"name": "", "type": "any"}],
                 "type": "function",
             },
             {
-                "inputs": [{"name": "id", "type": "uint256"}],
+                "inputs": [{"name": "id", "type": "int"}],
                 "name": "get_vector_metadata",
                 "outputs": [],
                 "type": "function",
             },
             {
-                "inputs": [{"name": "id", "type": "uint256"}],
+                "inputs": [{"name": "id", "type": "int"}],
                 "name": "remove_log",
                 "outputs": [],
                 "type": "function",
             },
             {
                 "inputs": [
-                    {"name": "id", "type": "uint256"},
+                    {"name": "id", "type": "int"},
                     {"name": "log", "type": "string"},
-                    {"name": "log_id", "type": "uint256"},
+                    {"name": "log_id", "type": "int"},
                 ],
                 "name": "update_log",
                 "outputs": [],

--- a/tests/integration/contract_examples/mocks/user_storage_get_contract_schema_for_code.py
+++ b/tests/integration/contract_examples/mocks/user_storage_get_contract_schema_for_code.py
@@ -13,7 +13,7 @@ user_storage_contract_schema = {
             {
                 "inputs": [],
                 "name": "get_complete_storage",
-                "outputs": [{"name": "", "type": "bytes"}],
+                "outputs": [{"name": "", "type": "any"}],
                 "type": "function",
             },
             {

--- a/tests/integration/contract_examples/test_async_init.py
+++ b/tests/integration/contract_examples/test_async_init.py
@@ -17,7 +17,7 @@ def test_async_init(setup_validators, from_account):
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
         from_account,
         contract_code,
-        "{}",
+        [],
     )
     assert has_success_status(transaction_response_deploy)
 

--- a/tests/integration/contract_examples/test_football_prediction_market.py
+++ b/tests/integration/contract_examples/test_football_prediction_market.py
@@ -33,7 +33,7 @@ def test_football_prediction_market(setup_validators, from_account):
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
         from_account,
         contract_code,
-        f'{{"game_date": "2024-06-26", "team1": "Georgia", "team2": "Portugal"}}',
+        ["2024-06-26", "Georgia", "Portugal"],
     )
     assert has_success_status(transaction_response_deploy)
 

--- a/tests/integration/contract_examples/test_llm_erc20.py
+++ b/tests/integration/contract_examples/test_llm_erc20.py
@@ -41,7 +41,7 @@ def test_llm_erc20(setup_validators):
 
     # Deploy Contract
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
-        from_account_a, contract_code, json.dumps({"total_supply": TOKEN_TOTAL_SUPPLY})
+        from_account_a, contract_code, [TOKEN_TOTAL_SUPPLY]
     )
 
     assert has_success_status(transaction_response_deploy)

--- a/tests/integration/contract_examples/test_log_indexer.py
+++ b/tests/integration/contract_examples/test_log_indexer.py
@@ -72,7 +72,7 @@ def test_log_indexer(setup_validators, from_account):
     # ######### Get log 0 metadata ###########
     # ########################################
     metadata_log_0 = call_contract_method(
-        contract_address, from_account, "get_vector_metadata", [0]
+        contract_address, from_account, "get_vector_metadata", [1]
     )
     assert metadata_log_0 == {"log_id": 0}
 
@@ -113,7 +113,7 @@ def test_log_indexer(setup_validators, from_account):
         contract_address, from_account, "get_closest_vector", ["I like mango a lot"]
     )
     assert float(closest_vector_log_0_2["similarity"]) > 0.85
-    assert float(closest_vector_log_0_2["similarity"]) < 0.86
+    assert float(closest_vector_log_0_2["similarity"]) < 0.87
 
     # ########################################
     # ########### Remove log 0 ##############
@@ -122,7 +122,7 @@ def test_log_indexer(setup_validators, from_account):
         from_account,
         contract_address,
         "remove_log",
-        [0],
+        [1],
     )
     assert has_success_status(transaction_response_remove_log_0)
 
@@ -153,5 +153,5 @@ def test_log_indexer(setup_validators, from_account):
         contract_address, from_account, "get_closest_vector", ["This is the third log"]
     )
     assert float(closest_vector_log_2["similarity"]) > 0.99
-    assert closest_vector_log_2["id"] == 2
+    assert closest_vector_log_2["id"] == 3
     assert closest_vector_log_2["text"] == "This is the third log"

--- a/tests/integration/contract_examples/test_log_indexer.py
+++ b/tests/integration/contract_examples/test_log_indexer.py
@@ -35,7 +35,7 @@ def test_log_indexer(setup_validators, from_account):
 
     # Deploy Contract
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
-        from_account, contract_code, "{}"
+        from_account, contract_code, []
     )
     assert has_success_status(transaction_response_deploy)
 

--- a/tests/integration/contract_examples/test_multi_read_erc20.py
+++ b/tests/integration/contract_examples/test_multi_read_erc20.py
@@ -36,7 +36,7 @@ def test_multi_read_erc20(setup_validators):
     doge_contract_address, transaction_response_deploy = deploy_intelligent_contract(
         from_account_doge,
         contract_code,
-        json.dumps({"total_supply": TOKEN_TOTAL_SUPPLY}),
+        [TOKEN_TOTAL_SUPPLY],
     )
     assert has_success_status(transaction_response_deploy)
 
@@ -45,7 +45,7 @@ def test_multi_read_erc20(setup_validators):
     shiba_contract_address, transaction_response_deploy = deploy_intelligent_contract(
         from_account_shiba,
         contract_code,
-        json.dumps({"total_supply": TOKEN_TOTAL_SUPPLY}),
+        [TOKEN_TOTAL_SUPPLY],
     )
     assert has_success_status(transaction_response_deploy)
 
@@ -56,7 +56,7 @@ def test_multi_read_erc20(setup_validators):
     multi_read_address, transaction_response_deploy = deploy_intelligent_contract(
         from_account_doge,
         contract_code,
-        json.dumps({}),
+        [],
     )
     assert has_success_status(transaction_response_deploy)
 

--- a/tests/integration/contract_examples/test_multi_tenant_storage.py
+++ b/tests/integration/contract_examples/test_multi_tenant_storage.py
@@ -39,7 +39,7 @@ def test_multi_tenant_storage(setup_validators):
         deploy_intelligent_contract(
             main_account,
             contract_code,
-            json.dumps({"initial_storage": "initial_storage_a"}),
+            ["initial_storage_a"],
         )
     )
     assert has_success_status(transaction_response_deploy)
@@ -50,7 +50,7 @@ def test_multi_tenant_storage(setup_validators):
         deploy_intelligent_contract(
             main_account,
             contract_code,
-            json.dumps({"initial_storage": "initial_storage_b"}),
+            ["initial_storage_b"],
         )
     )
     assert has_success_status(transaction_response_deploy)
@@ -63,14 +63,12 @@ def test_multi_tenant_storage(setup_validators):
         deploy_intelligent_contract(
             main_account,
             contract_code,
-            json.dumps(
-                {
-                    "storage_contracts": [
-                        first_storage_contract_address,
-                        second_storage_contract_address,
-                    ]
-                }
-            ),
+            [
+                [
+                    first_storage_contract_address,
+                    second_storage_contract_address,
+                ]
+            ],
         )
     )
     assert has_success_status(transaction_response_deploy)

--- a/tests/integration/contract_examples/test_read_erc20.py
+++ b/tests/integration/contract_examples/test_read_erc20.py
@@ -29,7 +29,7 @@ def test_read_erc20(setup_validators, from_account):
     last_contract_address, transaction_response_deploy = deploy_intelligent_contract(
         from_account,
         contract_code,
-        json.dumps({"total_supply": TOKEN_TOTAL_SUPPLY}),
+        [TOKEN_TOTAL_SUPPLY],
     )
     assert has_success_status(transaction_response_deploy)
 
@@ -44,7 +44,7 @@ def test_read_erc20(setup_validators, from_account):
             deploy_intelligent_contract(
                 from_account,
                 contract_code,
-                json.dumps({"token_contract": last_contract_address}),
+                [last_contract_address],
             )
         )
         assert has_success_status(transaction_response_deploy)

--- a/tests/integration/contract_examples/test_storage.py
+++ b/tests/integration/contract_examples/test_storage.py
@@ -35,7 +35,7 @@ def test_storage(setup_validators, from_account):
 
     # Deploy Contract
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
-        from_account, contract_code, f'{{"initial_storage": "{INITIAL_STATE}"}}'
+        from_account, contract_code, [INITIAL_STATE]
     )
 
     assert has_success_status(transaction_response_deploy)

--- a/tests/integration/contract_examples/test_user_storage.py
+++ b/tests/integration/contract_examples/test_user_storage.py
@@ -44,7 +44,7 @@ def test_user_storage(setup_validators):
     # Deploy Contract
     # Deploy Contract
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
-        from_account_a, contract_code, "{}"
+        from_account_a, contract_code, []
     )
 
     assert has_success_status(transaction_response_deploy)

--- a/tests/integration/contract_examples/test_wizard_of_coin.py
+++ b/tests/integration/contract_examples/test_wizard_of_coin.py
@@ -31,7 +31,7 @@ def test_wizard_of_coin(setup_validators, from_account):
 
     # Deploy Contract
     contract_address, transaction_response_deploy = deploy_intelligent_contract(
-        from_account, contract_code, f'{{"have_coin": true}}'
+        from_account, contract_code, [True]
     )
     assert has_success_status(transaction_response_deploy)
 

--- a/tests/unit/consensus/test_base.py
+++ b/tests/unit/consensus/test_base.py
@@ -142,9 +142,8 @@ async def test_exec_transaction():
             return_value=Receipt(
                 vote=Vote.AGREE,
                 class_name="",
-                args=[],
+                calldata=b"",
                 mode=mode,
-                method="",
                 gas_used=0,
                 contract_state="",
                 node_config={},
@@ -253,9 +252,8 @@ async def test_exec_transaction_no_consensus():
             return_value=Receipt(
                 vote=Vote.DISAGREE,
                 class_name="",
-                args=[],
+                calldata=b"",
                 mode=mode,
-                method="",
                 gas_used=0,
                 contract_state="",
                 node_config={},
@@ -369,9 +367,8 @@ async def test_exec_transaction_one_disagreement():
                     else Vote.DISAGREE
                 ),
                 class_name="",
-                args=[],
+                calldata=b"",
                 mode=mode,
-                method="",
                 gas_used=0,
                 contract_state="",
                 node_config={},


### PR DESCRIPTION
Fixes \<no issue\>

# What

<!-- Describe the changes you made. -->

- implemented new calldata encoding

# Why

- first step for migration to new genvm

# Testing done

- python file is taken from genvm, untested here
- ts parser is tested to some extent
- some manual testing was done

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->
For now there is a problem with "json" input by user for obvious reasons. I can allocate some time to fix them, but I am not great in reactive ui's

# User facing release notes

New calldata string representation is slightly different from json:
- it has bytes type (encoded in text as `b#`\<hex bytes>)
- it has address type (encoded in text as `addr#`\<64 hex digits>
- keys can omit `"`
