### PR TITLE
fix: hide methods during deployment to avoid pointing to the wrong contract instance

### DIFF
--- a/frontend/src/components/Simulator/ContractInfo.vue
+++ b/frontend/src/components/Simulator/ContractInfo.vue
@@ -5,6 +5,7 @@ import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vu
 import { PlusIcon } from '@heroicons/vue/16/solid';
 import { useNodeStore } from '@/stores';
 import { useWallet, useContractQueries } from '@/hooks';
+import { UploadIcon } from 'lucide-vue-next';
 
 const nodeStore = useNodeStore();
 const { shortenAddress } = useWallet();
@@ -64,9 +65,9 @@ const { isDeployed, address, contract } = useContractQueries();
       class="inline-flex w-auto shrink grow-0"
       v-else-if="showNewDeploymentButton"
       @click="emit('openDeployment')"
-      :icon="PlusIcon"
+      :icon="UploadIcon"
     >
-      New Deployment
+      Deploy new instance
     </Btn>
   </PageSection>
 </template>

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -118,6 +118,7 @@ export function useContractQueries() {
 
       transactionsStore.clearTransactionsForContract(contract.value?.id ?? '');
       transactionsStore.addTransaction(tx);
+      contractsStore.removeDeployedContract(contract.value?.id ?? '');
       return tx;
     } catch (error) {
       isDeploying.value = false;


### PR DESCRIPTION
Fixes #495 

# What

- Fixed the issue by removing deployed contract from store on deploy, effectively hiding methods UI when a new deployment is triggered
- Improved "new deployment" button icon/copy for clarity:
<img width="329" alt="image" src="https://github.com/user-attachments/assets/15497110-5edf-4b63-8037-ea2d72df38c1">

# Why

- to fix a bug
- to improve UX

# Testing done

- tested the bug fix
- frontend e2e ok
- frontend unit ok

# Decisions made

- Decided to improve some copy

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Validate that the copy makes sense for the button

# User facing release notes

- Fixed an issue with contract method not pointing to the correct contract instance during deployment
