### PR TITLE
feat: adding frontend profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   frontend:
+    profiles:
+      - frontend
     build:
       context: ./
       dockerfile: ./docker/Dockerfile.frontend


### PR DESCRIPTION
Fixes #594

## What

- Added a `frontend` profile to the `frontend` service in the `docker-compose.yml` file.
- Now, users can choose to start the simulator without the `frontend` UI by specifying or omitting the `frontend` profile.

## Why

- This change enables users to run the simulator in **headless mode**, making it more flexible by allowing services to start without the `frontend` UI when not needed. This addresses the need for lightweight, backend-only setups for local testing or headless environments.

## Testing done

- Tested running `docker compose up` to start all services without the `frontend` service.
- Tested `docker compose --profile frontend up` to start all services, including the `frontend` UI.
- Verified compatibility and successful startup on both **Debian** and **macOS** systems.

## Decisions made

- Used the `frontend` profile to simplify managing optional services without needing multiple Compose files or complex configurations.

## Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

## Reviewing tips

- The reviewer can check for proper use of the `frontend` profile in the `frontend` service to verify the service is now optional and can be included or excluded by specifying profiles.

## User facing release notes

- Users can now run the simulator in headless mode, omitting the `frontend` UI by default and enabling it when needed with `docker compose --profile frontend up`.