### PR TITLE
fix(ci): New Openhands URL

### DIFF
--- a/.github/workflows/openhands.yml
+++ b/.github/workflows/openhands.yml
@@ -22,7 +22,7 @@ jobs:
         startsWith(github.event.comment.body, vars.OPENHANDS_MACRO || '@openhands-agent') &&
         (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'MEMBER'))
       }}
-    uses: All-Hands-AI/openhands-resolver/.github/workflows/openhands-resolver.yml@main
+    uses: All-Hands-AI/OpenHands/.github/workflows/openhands-resolver.yml@main
     with:
       macro: ${{ vars.OPENHANDS_MACRO || '@openhands-agent' }}
       max_iterations: 50


### PR DESCRIPTION
Fixes #608

# What

- Updated the Openhands resolver integration to fix the breaking change that was introduced in the recent merge:
https://github.com/All-Hands-AI/OpenHands/pull/4964

# Why

- To resolve a bug that could disrupt Openhands functionality for devs after the move of the Openhands resolver repo.