### PR TITLE
fix: cross-client event logs on hosted env, tx async data inconsistencies

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -323,6 +323,7 @@ class ConsensusAlgorithm:
                     EventType.ERROR,
                     EventScope.CONSENSUS,
                     "Failed to reach consensus",
+                    transaction_hash=transaction.hash,
                 )
             )
             ConsensusAlgorithm.dispatch_transaction_status_update(
@@ -353,6 +354,7 @@ class ConsensusAlgorithm:
                 EventScope.CONSENSUS,
                 "Reached consensus",
                 consensus_data.to_dict(),
+                transaction_hash=transaction.hash,
             )
         )
 
@@ -367,7 +369,6 @@ class ConsensusAlgorithm:
                     },
                 }
                 leaders_contract_snapshot.register_contract(new_contract)
-
                 msg_handler.send_message(
                     LogEvent(
                         "deployed_contract",
@@ -375,6 +376,7 @@ class ConsensusAlgorithm:
                         EventScope.GENVM,
                         "Contract deployed",
                         new_contract,
+                        transaction_hash=transaction.hash,
                     )
                 )
 
@@ -492,6 +494,7 @@ class ConsensusAlgorithm:
                     "hash": str(transaction_hash),
                     "new_status": str(new_status.value),
                 },
+                transaction_hash=transaction_hash,
             )
         )
 

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -166,7 +166,11 @@ class Node:
         assert self.contract_snapshot is not None
         self.contract_snapshot.contract_code = code_to_deploy
         return await self._run_genvm(
-            from_address, calldata, readonly=False, is_init=True, transaction_hash=transaction_hash
+            from_address,
+            calldata,
+            readonly=False,
+            is_init=True,
+            transaction_hash=transaction_hash,
         )
 
     async def run_contract(

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -200,7 +200,7 @@ class Node:
         *,
         readonly: bool,
         is_init: bool,
-        transaction_hash: str,
+        transaction_hash: str | None = None,
     ) -> Receipt:
         genvm = self._create_genvm()
         leader_res: None | dict[int, bytes]

--- a/backend/protocol_rpc/message_handler/base.py
+++ b/backend/protocol_rpc/message_handler/base.py
@@ -42,19 +42,22 @@ class MessageHandler:
         return log_endpoint_info_wrapper(self, self.config)(func)
 
     def _socket_emit(self, log_event: LogEvent):
-        if log_event.name == "transaction_status_updated":
+        if log_event.transaction_hash:
             self.socketio.emit(
                 log_event.name,
                 log_event.to_dict(),
-                room=log_event.data.get("hash"),
+                room=log_event.transaction_hash,
             )
         else:
+            client_session_id = (
+                log_event.client_session_id
+                or self.client_session_id
+                or get_client_session_id()
+            )
             self.socketio.emit(
                 log_event.name,
                 log_event.to_dict(),
-                to=log_event.client_session_id
-                or self.client_session_id
-                or get_client_session_id(),
+                to=client_session_id,
             )
 
     def _log_message(self, log_event: LogEvent):

--- a/backend/protocol_rpc/message_handler/types.py
+++ b/backend/protocol_rpc/message_handler/types.py
@@ -22,6 +22,7 @@ class LogEvent:
     scope: EventScope
     message: str
     data: dict | None = None
+    transaction_hash: str | None = None
     client_session_id: str | None = None
 
     def to_dict(self):
@@ -31,5 +32,6 @@ class LogEvent:
             "scope": self.scope.value,
             "message": self.message,
             "data": self.data,
+            "transaction_hash": self.transaction_hash,
             "client_id": self.client_session_id,
         }

--- a/examples/contracts/wizard_of_coin.py
+++ b/examples/contracts/wizard_of_coin.py
@@ -15,7 +15,7 @@ class WizardOfCoin:
     def ask_for_coin(self, request: str) -> None:
         if not self.have_coin:
             return
-        
+
         prompt = f"""
 You are a wizard, and you hold a magical coin.
 Many adventurers will come and try to get you to give them the coin.
@@ -43,9 +43,11 @@ This result should be perfectly parseable by a JSON parser without errors.
             result = gl.exec_prompt(prompt)
             result = result.replace("```json", "").replace("```", "")
             print(result)
-            return result            
+            return result
 
-        result = gl.eq_principle_prompt_comparative(get_wizard_answer, "The value of give_coin has to match")
+        result = gl.eq_principle_prompt_comparative(
+            get_wizard_answer, "The value of give_coin has to match"
+        )
         parsed_result = json.loads(result)
         assert isinstance(parsed_result["give_coin"], bool)
         self.have_coin = not parsed_result["give_coin"]

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -19,14 +19,14 @@ const props = defineProps<{
 }>();
 
 const isExpanded = ref(false);
-const isReading = ref(false);
+const isCalling = ref(false);
 const responseMessage = ref('');
 
 const calldataArguments = ref<ArgData>({ args: [], kwargs: {} });
 
 const handleCallReadMethod = async () => {
   responseMessage.value = '';
-  isReading.value = true;
+  isCalling.value = true;
 
   try {
     const result = await callReadMethod(
@@ -51,29 +51,41 @@ const handleCallReadMethod = async () => {
       type: 'error',
     });
   } finally {
-    isReading.value = false;
+    isCalling.value = false;
   }
 };
 
 const handleCallWriteMethod = async () => {
-  await callWriteMethod({
-    method: props.name,
-    leaderOnly: props.leaderOnly,
-    args: unfoldArgsData({
-      args: calldataArguments.value.args,
-      kwargs: calldataArguments.value.kwargs,
-    }),
-  });
+  isCalling.value = true;
 
-  notify({
-    text: 'Write method called',
-    type: 'success',
-  });
+  try {
+    await callWriteMethod({
+      method: props.name,
+      leaderOnly: props.leaderOnly,
+      args: unfoldArgsData({
+        args: calldataArguments.value.args,
+        kwargs: calldataArguments.value.kwargs,
+      }),
+    });
 
-  trackEvent('called_write_method', {
-    contract_name: contract.value?.name || '',
-    method_name: props.name,
-  });
+    notify({
+      text: 'Write method called',
+      type: 'success',
+    });
+
+    trackEvent('called_write_method', {
+      contract_name: contract.value?.name || '',
+      method_name: props.name,
+    });
+  } catch (error) {
+    notify({
+      title: 'Error',
+      text: (error as Error)?.message || 'Error getting contract state',
+      type: 'error',
+    });
+  } finally {
+    isCalling.value = false;
+  }
 };
 </script>
 
@@ -113,9 +125,9 @@ const handleCallWriteMethod = async () => {
             @click="handleCallReadMethod"
             tiny
             :data-testid="`read-method-btn-${name}`"
-            :loading="isReading"
-            :disabled="isReading"
-            >{{ isReading ? 'Calling...' : 'Call Contract' }}</Btn
+            :loading="isCalling"
+            :disabled="isCalling"
+            >{{ isCalling ? 'Calling...' : 'Call Contract' }}</Btn
           >
 
           <Btn
@@ -123,7 +135,9 @@ const handleCallWriteMethod = async () => {
             @click="handleCallWriteMethod"
             tiny
             :data-testid="`write-method-btn-${name}`"
-            >Send Transaction</Btn
+            :loading="isCalling"
+            :disabled="isCalling"
+            >{{ isCalling ? 'Sending...' : 'Send Transaction' }}</Btn
           >
         </div>
 

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -1,8 +1,10 @@
 export const useConfig = () => {
   const isHostedEnvironment = import.meta.env.VITE_IS_HOSTED === 'true';
   const canUpdateValidators = !isHostedEnvironment;
+  const canUpdateProviders = !isHostedEnvironment;
 
   return {
     canUpdateValidators,
+    canUpdateProviders,
   };
 };

--- a/frontend/src/stores/contracts.ts
+++ b/frontend/src/stores/contracts.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { notify } from '@kyvg/vue3-notification';
 import { useDb, useFileName, useSetupStores } from '@/hooks';
+import { useTransactionsStore } from '@/stores';
 
 export const useContractsStore = defineStore('contractsStore', () => {
   const contracts = ref<ContractFile[]>([]);
@@ -10,6 +11,7 @@ export const useContractsStore = defineStore('contractsStore', () => {
   const db = useDb();
   const { setupStores } = useSetupStores();
   const { cleanupFileName } = useFileName();
+  const transactionsStore = useTransactionsStore();
 
   const currentContractId = ref<string | undefined>(
     localStorage.getItem('contractsStore.currentContractId') || '',
@@ -147,6 +149,10 @@ export const useContractsStore = defineStore('contractsStore', () => {
         .anyOf(idsToDelete)
         .delete();
       await db.contractFiles.where('id').anyOf(idsToDelete).delete();
+
+      idsToDelete.forEach((id) => {
+        transactionsStore.clearTransactionsForContract(id);
+      });
 
       deployedContracts.value = [
         ...deployedContracts.value.filter(

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -58,7 +58,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     await Promise.all(
       pendingTxs.map(async (tx) => {
         const newTx = await getTransaction(tx.hash);
-        
+
         if (newTx) {
           updateTransaction(newTx);
           await db.transactions.where('hash').equals(tx.hash).modify({

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import type { TransactionItem } from '@/types';
-import { useRpcClient, useWebSocketClient } from '@/hooks';
+import { useDb, useRpcClient, useWebSocketClient } from '@/hooks';
 import { useContractsStore } from '@/stores';
 
 export const useTransactionsStore = defineStore('transactionsStore', () => {
@@ -10,6 +10,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   const transactions = ref<TransactionItem[]>([]);
   const contractsStore = useContractsStore();
   const subscriptions = new Set();
+  const db = useDb();
 
   function addTransaction(tx: TransactionItem) {
     transactions.value.unshift(tx); // Push on top in case there's no date property yet
@@ -57,7 +58,17 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     await Promise.all(
       pendingTxs.map(async (tx) => {
         const newTx = await getTransaction(tx.hash);
-        updateTransaction(newTx);
+        
+        if (newTx) {
+          updateTransaction(newTx);
+          await db.transactions.where('hash').equals(tx.hash).modify({
+            status: newTx.status,
+            data: newTx,
+          });
+        } else {
+          removeTransaction(tx);
+          await db.transactions.where('hash').equals(tx.hash).delete();
+        }
       }),
     );
   }
@@ -66,7 +77,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     return rpcClient.getTransactionByHash(hash);
   }
 
-  function clearTransactionsForContract(contractId: string) {
+  async function clearTransactionsForContract(contractId: string) {
     const contractTxs = transactions.value.filter(
       (t) => t.localContractId === contractId,
     );
@@ -76,6 +87,8 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     transactions.value = transactions.value.filter(
       (t) => t.localContractId !== contractId,
     );
+
+    await db.transactions.where('localContractId').equals(contractId).delete();
   }
 
   function subscribe(topics: string[]) {

--- a/frontend/src/views/Simulator/SettingsView.vue
+++ b/frontend/src/views/Simulator/SettingsView.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
+import { useConfig } from '@/hooks';
 import MainTitle from '@/components/Simulator/MainTitle.vue';
 import ProviderSection from '@/components/Simulator/settings/ProviderSection.vue';
 import SimulatorSection from '@/components/Simulator/settings/SimulatorSection.vue';
+
+const { canUpdateProviders } = useConfig();
 </script>
 
 <template>
@@ -9,6 +12,6 @@ import SimulatorSection from '@/components/Simulator/settings/SimulatorSection.v
     <MainTitle data-testid="settings-page-title">Settings</MainTitle>
 
     <SimulatorSection />
-    <ProviderSection />
+    <ProviderSection v-if="canUpdateProviders" />
   </div>
 </template>

--- a/frontend/test/unit/stores/contracts.test.ts
+++ b/frontend/test/unit/stores/contracts.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useContractsStore } from '@/stores';
-import { useDb, useFileName, useSetupStores, useRpcClient, useWebSocketClient } from '@/hooks';
+import {
+  useDb,
+  useFileName,
+  useSetupStores,
+  useRpcClient,
+  useWebSocketClient,
+} from '@/hooks';
 import { notify } from '@kyvg/vue3-notification';
 
 const testContract = {

--- a/frontend/test/unit/stores/contracts.test.ts
+++ b/frontend/test/unit/stores/contracts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useContractsStore } from '@/stores';
-import { useDb, useFileName, useSetupStores } from '@/hooks';
+import { useDb, useFileName, useSetupStores, useRpcClient, useWebSocketClient } from '@/hooks';
 import { notify } from '@kyvg/vue3-notification';
 
 const testContract = {
@@ -21,6 +21,8 @@ vi.mock('@/hooks', () => ({
   useDb: vi.fn(),
   useFileName: vi.fn(),
   useSetupStores: vi.fn(),
+  useRpcClient: vi.fn(),
+  useWebSocketClient: vi.fn(),
 }));
 
 vi.mock('@kyvg/vue3-notification', () => ({
@@ -40,6 +42,11 @@ describe('useContractsStore', () => {
       anyOf: vi.fn().mockReturnThis(),
       delete: vi.fn(),
     },
+    transactions: {
+      where: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockResolvedValue(undefined),
+    },
   };
 
   const mockFileName = {
@@ -55,6 +62,8 @@ describe('useContractsStore', () => {
     (useDb as Mock).mockReturnValue(mockDb);
     (useFileName as Mock).mockReturnValue(mockFileName);
     (useSetupStores as Mock).mockReturnValue(mockSetupStores);
+    (useRpcClient as Mock).mockReturnValue({});
+    (useWebSocketClient as Mock).mockReturnValue({});
 
     contractsStore = useContractsStore();
     vi.clearAllMocks();

--- a/frontend/test/unit/stores/transactions.test.ts
+++ b/frontend/test/unit/stores/transactions.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useTransactionsStore } from '@/stores';
-import { useRpcClient } from '@/hooks';
+import { useDb, useRpcClient } from '@/hooks';
 import { type TransactionItem } from '@/types';
 
 vi.mock('@/hooks', () => ({
@@ -44,10 +44,20 @@ describe('useTransactionsStore', () => {
   const mockRpcClient = {
     getTransactionByHash: vi.fn(),
   };
+  const mockDb = {
+    transactions: {
+      where: vi.fn().mockReturnThis(),
+      anyOf: vi.fn().mockReturnThis(),
+      equals: vi.fn().mockReturnThis(),
+      modify: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn(),
+    },
+  };
 
   beforeEach(() => {
     setActivePinia(createPinia());
     (useRpcClient as Mock).mockReturnValue(mockRpcClient);
+    (useDb as Mock).mockReturnValue(mockDb);
     transactionsStore = useTransactionsStore();
     transactionsStore.transactions = [];
     mockRpcClient.getTransactionByHash.mockClear();
@@ -101,6 +111,10 @@ describe('useTransactionsStore', () => {
 
     transactionsStore.clearTransactionsForContract('contract-1');
 
+    expect(mockDb.transactions.where).toHaveBeenCalledWith('localContractId');
+    expect(mockDb.transactions.equals).toHaveBeenCalledWith('contract-1');
+    expect(mockDb.transactions.delete).toHaveBeenCalled();
+
     expect(transactionsStore.transactions).toEqual([tx2]);
   });
 
@@ -122,6 +136,14 @@ describe('useTransactionsStore', () => {
     expect(mockRpcClient.getTransactionByHash).toHaveBeenCalledWith(
       pendingTransaction.hash,
     );
+    expect(mockDb.transactions.where).toHaveBeenCalledWith('hash');
+    expect(mockDb.transactions.equals).toHaveBeenCalledWith(
+      pendingTransaction.hash,
+    );
+    expect(mockDb.transactions.modify).toHaveBeenCalledWith({
+      status: 'FINALIZED',
+      data: updatedTransaction,
+    });
     expect(transactionsStore.transactions[0].status).toBe('FINALIZED');
   });
 });


### PR DESCRIPTION
# What

- Fixes **event logs sent across users on hosted environment** (the issue appeared with the genvm integration; we were not tracking the client session id on genvm/consensus-related events anymore, effectively dispatching them to all clients. To fix this, I added the transaction hash-scoping to those events as well).
- **Adds a loading state on call method buttons** (wasn't needed before because it was instant; now that the call takes a bit of time it's better for ux responsiveness to set the button to a loading state while the call is processing).
- **Hide provider settings** when on hosted environment
- Fixes **transaction async data errors and inconsistencies** (specifically: handling the case where a server tx doesn't exists anymore after a db reset properly and clearing local txs if their server equivalent doesn't exists anymore; 'reset storage' was only clearing the (example) contracts and not their related client txs - I made sure that those are now removed from the storage as well).

# Why

- To fix some bugs on the hosted environment
- To fix some bugs related to tx async data
- To improve UX

# Testing done

- Tested the fixes and features
- Updated unit tests
- frontend units OK
- frontend e2e OK

# Decisions made

- Added a transaction_hash parameter to the LogEvent class in the backend in order to use it as a room filter for websocket events.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips:
- @kp2pml30 can you confirm it's OK to pass transaction_hash as a parameter in the genvm-related methods?